### PR TITLE
feat(core): A new`uiFor` prop (passed down to elements).

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "eslint-plugin-react-native": "^2.3.1",
     "eslint-stats": "^0.1.4",
     "jest": "^19.0.2",
+    "jest-enzyme": "^3.0.0",
     "lerna": "2.0.0-beta.38",
     "react": "^15.3.2",
     "react-addons-test-utils": "^15.2.1",
@@ -65,6 +66,7 @@
     "redux": "^3.0.0"
   },
   "jest": {
+    "setupTestFrameworkScriptFile": "./node_modules/jest-enzyme/lib/index.js",   
     "modulePathIgnorePatterns": [
       "/build/es5/"
     ],

--- a/packages/core/src/__tests__/ui.js
+++ b/packages/core/src/__tests__/ui.js
@@ -1,13 +1,13 @@
 'use strict';
 
-
-import { render } from 'enzyme';
+import { render, shallow, mount } from 'enzyme';
 
 import React from 'react';
-import { List, fromJS } from 'immutable';
+import { Iterable, List, fromJS } from 'immutable';
 import Cursor from 'immutable/contrib/cursor';
 
 import { ui, Engine } from '..';
+import { kindOf, isOfKind } from '../common/element';
 
 import { isSubclassOf } from '../common/classes';
 
@@ -162,6 +162,84 @@ describe("ui", () => {
         expect(html).toContain('Watson');
         expect(html).toContain('Hudson');
         expect(html.match(/<div>/g).length).toEqual(3);
+      });
+    });
+
+    describe('element#uiFor', () => {
+      beforeEach(() => {
+        ui.register('root', () => <div>Root mounted</div>);
+        ui.register('comp1', () => <div className='c1'>Comp1 mounted</div>);
+        ui.register('comp2', () => <div className='c2'>Comp2 mounted</div>);
+      });
+      afterEach(() => {
+        ui.reset();
+      });
+
+      function implFor(el) {
+        let impl = null;
+
+        ui.register(kindOf(el), ({uiFor}) => {
+          impl = uiFor;
+          return <div></div>;
+        });
+
+        mount(ui.forElement(el)); // triggers the renders
+        return impl;
+      }
+
+      describe('using a key path (string or array)', () => {
+        const state = Cursor.from(fromJS({
+          kind: 'root',
+          child1: {
+            'kind': 'comp1',
+            items: [
+              {
+                kind: 'comp2',
+                child: {
+                  kind: 'comp2'
+                }
+              },
+              {
+                kind: 'comp2',
+              },
+              {
+                kind: 'comp3'
+              }
+            ]
+          },
+          notAnElement: {
+            title: 'foo',
+          },
+        }));
+
+        let uiFor;
+        beforeEach(() => { uiFor = implFor(state) });
+
+        it('renders the ui for the element under the specified sub-key path', () => {
+          expect(mount(uiFor('child1'))).toContainReact(<div className='c1'>Comp1 mounted</div>);
+        });
+        it('renders the ui for the elements under the specified sub-key-path, if said key path is an array', () => {
+          expect(mount(uiFor(['child1', 'items', 0, 'child']))).toContainReact(<div className='c2'>Comp2 mounted</div>);
+        });
+        it('returns undefined if there is no ui registered for the elemnent under the key path', () => {
+          expect(uiFor('nonExistingChild') == null).toBe(true);
+          expect(uiFor(['child1', 'items', 100]) == null).toBe(true);
+        });
+        it('returns a list of UI if under there is a List of elements under the specified key path', () => {
+          const ui = uiFor(['child1', 'items']);
+          expect(Iterable.isIndexed(ui)).toEqual(true);
+          expect(mount(ui.get(0))).toContainReact(<div className='c2'>Comp2 mounted</div>);
+          expect(mount(ui.get(1))).toContainReact(<div className='c2'>Comp2 mounted</div>);
+        });
+        it('returns a list of UI elements only for those elements that have a registered UI', () => {
+          const ui = uiFor(['child1', 'items']);
+          for (let u of ui) {
+            expect(isOfKind(['comp3'], u.props.element)).toEqual(false);
+          }
+        });
+        it('throws and error if the data structure under the specified path is not an element', () => {
+          expect(() => uiFor('notAnElement')).toThrow();
+        });
       });
     });
   });

--- a/packages/core/src/__tests__/ui.js
+++ b/packages/core/src/__tests__/ui.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import { render, shallow, mount } from 'enzyme';
+import { render, mount } from 'enzyme';
 
 import React from 'react';
 import { Iterable, List, fromJS } from 'immutable';

--- a/packages/core/src/common/__tests__/element.js
+++ b/packages/core/src/common/__tests__/element.js
@@ -1,9 +1,38 @@
 'use strict';
 
 import { List, Seq, fromJS } from 'immutable';
-import { isOfKind, isExactlyOfKind, kindOf, ancestorKinds, canonical } from '../element';
+import { isOfKind, isExactlyOfKind, kindOf, ancestorKinds, canonical, isElement } from '../element';
 
 describe('element', function() {
+
+  it('tests if an object is an element', () => {
+    const emptyKind = fromJS({
+      'kind': []
+    });
+    const stringKind = fromJS({
+      'kind': 'component'
+    });
+    const singleKind = fromJS({
+      'kind': ['component']
+    });
+    const doubleKind = fromJS({
+      'kind': ['component', 'test']
+    });
+
+    const noKind = fromJS({
+      title: 'bla'
+    });
+    const aList = List.of(stringKind, singleKind, doubleKind, emptyKind);
+
+
+    expect(isElement(emptyKind)).toBeTruthy();
+    expect(isElement(stringKind)).toBeTruthy();
+    expect(isElement(singleKind)).toBeTruthy();
+    expect(isElement(doubleKind)).toBeTruthy();
+
+    expect(isElement(noKind)).toEqual(false);
+    expect(isElement(aList)).toEqual(false);
+  });
 
   it('properly checks for element kinds', function() {
     const emptyKind = fromJS({

--- a/packages/core/src/common/element.js
+++ b/packages/core/src/common/element.js
@@ -3,7 +3,7 @@
 
 import { all } from 'ramda';
 import invariant from 'invariant';
-import { List, Seq, is, KeyedIterable, IndexedIterable } from 'immutable';
+import { List, Seq, is, Iterable, KeyedIterable, IndexedIterable  } from 'immutable';
 
 import type { ElementRef, ElementRefCanonical } from './types';
 
@@ -43,6 +43,10 @@ export function isElementRef(obj: any): boolean {
   if (obj instanceof List && (obj.every(isString) || obj.isEmpty())) return true;
 
   return false;
+}
+
+export function isElement(obj: any): boolean {
+  return Iterable.isIterable(obj) && kindOf(obj) != null;
 }
 
 /**
@@ -143,4 +147,3 @@ function normalize(kind): ?List<string> {
 
   return null;
 }
-

--- a/yarn.lock
+++ b/yarn.lock
@@ -1277,6 +1277,12 @@ decamelize@^1.0.0, decamelize@^1.1.1, decamelize@^1.1.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
 
+deep-equal-ident@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/deep-equal-ident/-/deep-equal-ident-1.1.1.tgz#06f4b89e53710cd6cea4a7781c7a956642de8dc9"
+  dependencies:
+    lodash.isequal "^3.0"
+
 deep-extend@~0.4.0:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.4.1.tgz#efe4113d08085f4e6f9687759810f807469e2253"
@@ -1415,6 +1421,24 @@ encoding@^0.1.11:
 entities@^1.1.1, entities@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
+
+enzyme-matchers@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/enzyme-matchers/-/enzyme-matchers-2.1.2.tgz#da2c20c3d55b128db3de6a5016f2531066b8061f"
+  dependencies:
+    deep-equal-ident "^1.1.1"
+
+enzyme-to-json@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/enzyme-to-json/-/enzyme-to-json-1.5.0.tgz#bb94f21346866d68378adc9b26856dd6e2bfa60b"
+  dependencies:
+    lodash.filter "^4.6.0"
+    lodash.isnil "^4.0.0"
+    lodash.isplainobject "^4.0.6"
+    lodash.omitby "^4.5.0"
+    lodash.range "^3.2.0"
+    object-values "^1.0.0"
+    object.entries "^1.0.3"
 
 enzyme@^2.4.1:
   version "2.7.1"
@@ -2552,6 +2576,13 @@ jest-environment-node@^19.0.2:
     jest-mock "^19.0.0"
     jest-util "^19.0.2"
 
+jest-enzyme@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/jest-enzyme/-/jest-enzyme-3.0.0.tgz#662ea177f22af26a956482e6990621c026720a80"
+  dependencies:
+    enzyme-matchers "^2.1.2"
+    enzyme-to-json "^1.5.0"
+
 jest-file-exists@^19.0.0:
   version "19.0.0"
   resolved "https://registry.yarnpkg.com/jest-file-exists/-/jest-file-exists-19.0.0.tgz#cca2e587a11ec92e24cfeab3f8a94d657f3fceb8"
@@ -2869,6 +2900,22 @@ lodash-es@^4.2.1:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.4.tgz#dcc1d7552e150a0640073ba9cb31d70f032950e7"
 
+lodash._baseisequal@^3.0.0:
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/lodash._baseisequal/-/lodash._baseisequal-3.0.7.tgz#d8025f76339d29342767dcc887ce5cb95a5b51f1"
+  dependencies:
+    lodash.isarray "^3.0.0"
+    lodash.istypedarray "^3.0.0"
+    lodash.keys "^3.0.0"
+
+lodash._bindcallback@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
+
+lodash._getnative@^3.0.0:
+  version "3.9.1"
+  resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
+
 lodash._reinterpolate@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
@@ -2885,7 +2932,7 @@ lodash.defaults@^4.0.1:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c"
 
-lodash.filter@^4.4.0:
+lodash.filter@^4.4.0, lodash.filter@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.filter/-/lodash.filter-4.6.0.tgz#668b1d4981603ae1cc5a6fa760143e480b4c4ace"
 
@@ -2897,6 +2944,41 @@ lodash.foreach@^4.3.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.foreach/-/lodash.foreach-4.5.0.tgz#1a6a35eace401280c7f06dddec35165ab27e3e53"
 
+lodash.isarguments@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz#2f573d85c6a24289ff00663b491c1d338ff3458a"
+
+lodash.isarray@^3.0.0:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/lodash.isarray/-/lodash.isarray-3.0.4.tgz#79e4eb88c36a8122af86f844aa9bcd851b5fbb55"
+
+lodash.isequal@^3.0:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-3.0.4.tgz#1c35eb3b6ef0cd1ff51743e3ea3cf7fdffdacb64"
+  dependencies:
+    lodash._baseisequal "^3.0.0"
+    lodash._bindcallback "^3.0.0"
+
+lodash.isnil@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/lodash.isnil/-/lodash.isnil-4.0.0.tgz#49e28cd559013458c814c5479d3c663a21bfaa6c"
+
+lodash.isplainobject@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
+
+lodash.istypedarray@^3.0.0:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/lodash.istypedarray/-/lodash.istypedarray-3.0.6.tgz#c9a477498607501d8e8494d283b87c39281cef62"
+
+lodash.keys@^3.0.0:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/lodash.keys/-/lodash.keys-3.1.2.tgz#4dbc0472b156be50a0b286855d1bd0b0c656098a"
+  dependencies:
+    lodash._getnative "^3.0.0"
+    lodash.isarguments "^3.0.0"
+    lodash.isarray "^3.0.0"
+
 lodash.map@^4.4.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.map/-/lodash.map-4.6.0.tgz#771ec7839e3473d9c4cde28b19394c3562f4f6d3"
@@ -2905,9 +2987,17 @@ lodash.merge@^4.0.2, lodash.merge@^4.4.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.0.tgz#69884ba144ac33fe699737a6086deffadd0f89c5"
 
+lodash.omitby@^4.5.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.omitby/-/lodash.omitby-4.6.0.tgz#5c15ff4754ad555016b53c041311e8f079204791"
+
 lodash.pick@^4.2.1:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.pick/-/lodash.pick-4.4.0.tgz#52f05610fff9ded422611441ed1fc123a03001b3"
+
+lodash.range@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.range/-/lodash.range-3.2.0.tgz#f461e588f66683f7eadeade513e38a69a565a15d"
 
 lodash.reduce@^4.4.0:
   version "4.6.0"
@@ -3191,6 +3281,10 @@ object-is@^1.0.1:
 object-keys@^1.0.10, object-keys@^1.0.8:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.11.tgz#c54601778ad560f1142ce0e01bcca8b56d13426d"
+
+object-values@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/object-values/-/object-values-1.0.0.tgz#72af839630119e5b98c3b02bb8c27e3237158105"
 
 object.assign@^4.0.4:
   version "4.0.4"


### PR DESCRIPTION
The element's UI component is passed down a uiFor fn which is used to 'navigate down' the structure of the elements.

Example:

```javascript
// instead of 
import ui from '@girders-elements/core';

ui.register('dummy', ({element}) => {
  return (
    <div>{ui.forElement(element.get('child'))}</div>
 );
});

// use 

ui.register('dummy', ({element, uiFor}) => {
  return (
    <div>
      {uiFor('child')}
      <p>Also works with lists</p>
      {uiFor('items')} 
    </div>
 );
});
      
```