### PR TITLE
feat(core): deprecate ui.forElement and ui.forElements

### DIFF
--- a/packages/core/src/__tests__/ui.js
+++ b/packages/core/src/__tests__/ui.js
@@ -115,7 +115,7 @@ describe("ui", () => {
     describe("#forElement", () => {
 
       it("Requires a cursor around the element", () => {
-        expect(ui.forElement(fromJS({kind: 'comp1'}))).toThrow();
+        expect(() => ui.forElement(fromJS({kind: 'comp1'}))).toThrow();
         expect(ui.forElement(Cursor.from(fromJS({kind: 'comp1'})))).toEqual(expect.anything());
       });
 
@@ -243,6 +243,4 @@ describe("ui", () => {
       });
     });
   });
-
-
 });

--- a/packages/core/src/impl/deprecated.js
+++ b/packages/core/src/impl/deprecated.js
@@ -1,0 +1,34 @@
+'use strict';
+
+import 'core-js/fn/object/assign';
+
+import warning from './warning';
+
+/**
+ * This will log a single deprecation notice per function and forward the call
+ * on to the new API.
+ *
+ * @param {string} message The deprecation message.
+` * @param {*} ctx The context this forwarded call should run in
+ * @param {function} fn The function to forward on to
+ * @return {function} The function that will warn once and then call fn
+ */
+export default function deprecated(message, fn) {
+  var warned = false;
+  if (process.env.NODE_ENV !== 'production') {
+    var newFn = function () {
+      if (process.env.NODE_ENV !== 'production') {
+        if (!warned) {
+          warning(message);
+          warned = true;
+        }
+        return fn.apply(this, arguments);
+      }
+    };
+    Object.assign(newFn, fn);
+
+    return newFn;
+  }
+
+  return fn;
+}

--- a/packages/core/src/impl/warning.js
+++ b/packages/core/src/impl/warning.js
@@ -1,0 +1,13 @@
+'use strict';
+
+/* eslint-disable no-console */
+export default function warning(msg) {
+  if (typeof console !== undefined) {
+    if (console.warn != null) {
+      console.warn(msg);
+    } else if (console.error != null) {
+      console.error(msg);
+    }
+  }
+}
+/* eslint-enable no-console */


### PR DESCRIPTION
The `ui.forElement`and `ui.forElements` functions are deprecated and will be removed in a future release. Please use `uiFor` function provided as a property to your element ui implementation.

Each element in the UI tree must refer to an *unchanged* element in the state tree. Allowing arbitrary calls to `forElement(s)` allows the users to transform elements in an e.g. parent node before passing them down to child nodes, so they are deprecated.

Imposing this restriction allows us to optimize the re-rendering calls to just the sub-tree where the change had happened. This is an important optimization as a top-level elements often use 3rd party heavy components (e.g. react-navigation) which aren't optimized for frequent re-rendering like ordinary element UI is.

 