### PR TITLE
Introduce support for multivalue reads

### DIFF
--- a/packages/core/src/__tests__/readMultivalue.js
+++ b/packages/core/src/__tests__/readMultivalue.js
@@ -1,0 +1,67 @@
+'use strict';
+
+import { mount } from 'enzyme';
+
+import React from 'react';
+import { fromJS } from 'immutable';
+import { ui, read, Engine } from '..';
+
+
+describe('Reads', () => {
+
+  const appStateWithMetadata = {
+    kind: 'app',
+    content: {
+      kind: ['__read', 'scene'],
+      uri: 'https://netcetera.com/test.json',
+      where: ['children', 'metadata']
+    }
+  };
+
+  const serverResponse = {
+    metadata: {
+      title: 'Scene title'
+    },
+    children: [
+      {
+        kind: 'widget'
+      },
+      {
+        kind: 'widget'
+      }
+    ]
+  }
+  beforeEach(() => {
+    ui.register('app', ({ uiFor }) => {
+      return (
+        <div>{uiFor('content')}</div>
+      );
+    });
+    ui.register('scene', () => {
+      return (
+        <div>Scene</div>
+      );
+    });
+    read.register(/test\.json$/, () => Promise.resolve( { value: serverResponse }));
+  });
+
+  afterEach(() => {
+    ui.reset();
+  });
+
+  it('should succeed when found proper response with metadata', done => {
+    const engine = mount(<Engine initState={fromJS(appStateWithMetadata)} />);
+    let html = engine.html();
+    expect(html).toMatch('loading...');
+    expect(html).not.toMatch('Scene');
+
+    setTimeout(() => {
+      html = engine.html();
+      expect(html).not.toMatch('loading...');
+      expect(html).toMatch('Scene');
+      expect(engine.state().store.getState().getIn(['content', 'metadata', 'title'])).toEqual("Scene title")
+      done();
+    }, 500);
+  });
+
+});

--- a/packages/core/src/read/elements/loading.js
+++ b/packages/core/src/read/elements/loading.js
@@ -15,7 +15,10 @@ class Loading extends React.Component {
       React.PropTypes.arrayOf(React.PropTypes.string)
     ]).isRequired,
     uri: React.PropTypes.string.isRequired,
-    where: React.PropTypes.string.isRequired,
+    where: React.PropTypes.oneOfType([
+      React.PropTypes.string,
+      React.PropTypes.object
+    ]).isRequired,
     readId: React.PropTypes.string.isRequired
   };
 

--- a/packages/core/src/read/elements/read.js
+++ b/packages/core/src/read/elements/read.js
@@ -13,7 +13,10 @@ class Read extends React.Component {
       React.PropTypes.arrayOf(React.PropTypes.string)
     ]).isRequired,
     uri: React.PropTypes.string.isRequired,
-    where: React.PropTypes.string.isRequired
+    where: React.PropTypes.oneOfType([
+      React.PropTypes.string,
+      React.PropTypes.object
+    ]).isRequired
   };
 
   constructor(props) {


### PR DESCRIPTION
Modified the reads to support multivalues.
The 'where' attribute of the read object can can take an array of strings, representing the keys

**Ex:**
Response from 'request url' is:
```javascript
{
    'metadata': {
        title: 'Title'
    },
    'body': {
        'kind': 'widget'
    }
}
```

Before read:
```javascript
{
    'kind': ['__read', 'scene'],
    'uri': '<request url>',
    'where': ['metadata', 'body']
  }
```

After read:
```javascript
{
     'kind': ['scene'],
     'uri': '<request url>',
     'where': ['metadata', 'body'],
     'metadata': {
         title: 'Title'
    },
    'body': {
         'kind': 'widget'
    }
}
```
