### PR TITLE
Simplify reads

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,9 +282,7 @@ In this example, for the `article` **element** we register two **updates**:
 
 Reads are a standardaized way to bring data into you app. Most prominent use-case is fetching data from the back-end systems.
 
-Reads are started by preparing:
-- the **endpoint** from where the data is going to be fetched
-- the **place** where you want the data to be stored (attached) when its successfully fetched
+Reads are started by preparing the **endpoint** from where the data is going to be fetched
 
 To kick-off a read, you create an **element** with the following structure, on the **place** where you want the data to be attached:
 
@@ -297,12 +295,38 @@ To kick-off a read, you create an **element** with the following structure, on t
 
 This **read** element, is being resolved, because the frame-work contains a default element registered for the kind `__read`. It doesn't render any UI. This element dispatches a special action and changes the kind to `["__load", "conatiner", "teasers"]`.
 
-Again, there is a default element, registered for `__load`. It renders a loading spinner on the screen. It also disaptches a special action, that will perfrom the actuall fetching of the data. If the data is fetched successfully, then the data will be stored in the node named `children`, and the first element in the kind array will be removed. This will essentially transform the data to:
+Again, there is a default element, registered for `__load`. It renders a loading spinner on the screen. It also disaptches a special action, that will perfrom the actuall fetching of the data. If the data is fetched successfully, then the data will be stored in the node which initiated the read, overriding all the existing attributes.
+Assuming the server response is the following JSON:
 
 ```javascript
 {
   "kind": ["container", "teasers"],
-  "uri": "",
+  "children": [
+    {
+      "kind":[
+         "teaser",
+         "image"
+      ],
+      "imageUrl":"http://spyhollywood.com/wp-content/uploads/2016/06/sherlock.jpg",
+      "title":"Sherlock Holmes"
+    },
+    {
+      "kind":[
+         "teaser",
+         "image"
+      ],
+      "imageUrl":"http://img15.deviantart.net/6ee0/i/2010/286/2/2/dr__watson_by_elenutza-d30o87s.png",
+      "title":"Dr. Watson"
+    }
+  ]
+}
+```
+
+This will essentially transform the data to:
+
+```javascript
+{
+  "kind": ["container", "teasers"],
   "children": [
     {
       "kind":[

--- a/packages/core/src/__tests__/read.js
+++ b/packages/core/src/__tests__/read.js
@@ -28,7 +28,7 @@ describe('Reads', () => {
         <div>Scene</div>
       );
     });
-    read.register(/test\.json$/, u => Promise.resolve({value: {kind: 'scene'}, meta: read.responseMeta({url: u})}));
+    read.register(/test\.json$/, u => Promise.resolve({value: {kind: 'scene', title: 'Scene Title'}, meta: read.responseMeta({url: u})}));
 
   });
 
@@ -48,6 +48,9 @@ describe('Reads', () => {
     setTimeout(() => {
       const scenes = engine.findWhere(c => isOfKind('scene', c.prop('element')));
       expect(scenes.length).toBeGreaterThan(0);
+
+      const scene = scenes.first();
+      expect(scene.prop('element').get('title')).toEqual('Scene Title');
       done();
     }, 500);
   });

--- a/packages/core/src/__tests__/read.js
+++ b/packages/core/src/__tests__/read.js
@@ -4,8 +4,8 @@ import { mount } from 'enzyme';
 
 import React from 'react';
 import { fromJS } from 'immutable';
-import { ui, read, Engine } from '..';
-
+import { ui, read, data, Engine } from '..';
+const { isOfKind } = data.element;
 
 describe('Reads', () => {
 
@@ -38,14 +38,16 @@ describe('Reads', () => {
 
   it('should succeed when found proper response', done => {
     const engine = mount(<Engine initState={fromJS(appState)} />);
+    const loadingEls = engine.findWhere(c => isOfKind('__loading', c.prop('element')));
+    expect(loadingEls.length).toBeGreaterThan(0);
+
     let html = engine.html();
     expect(html).toMatch('loading...');
     expect(html).not.toMatch('Scene');
 
     setTimeout(() => {
-      html = engine.html();
-      expect(html).not.toMatch('loading...');
-      expect(html).toMatch('Scene');
+      const scenes = engine.findWhere(c => isOfKind('scene', c.prop('element')));
+      expect(scenes.length).toBeGreaterThan(0);
       done();
     }, 500);
   });

--- a/packages/core/src/__tests__/read.js
+++ b/packages/core/src/__tests__/read.js
@@ -13,8 +13,7 @@ describe('Reads', () => {
     kind: 'app',
     content: {
       kind: ['__read', 'scene'],
-      uri: 'https://netcetera.com/test.json',
-      where: 'children'
+      uri: 'https://netcetera.com/test.json'
     }
   };
 

--- a/packages/core/src/read/elements/loading.js
+++ b/packages/core/src/read/elements/loading.js
@@ -15,7 +15,6 @@ class Loading extends React.Component {
       React.PropTypes.arrayOf(React.PropTypes.string)
     ]).isRequired,
     uri: React.PropTypes.string.isRequired,
-    where: React.PropTypes.string.isRequired,
     readId: React.PropTypes.string.isRequired
   };
 
@@ -24,8 +23,8 @@ class Loading extends React.Component {
   }
 
   componentDidMount() {
-    const { dispatch, kind, uri, where, readId } = this.props;
-    dispatch({type: 'READ_PERFORM', uri, where, kind, readId});
+    const { dispatch, kind, uri, readId } = this.props;
+    dispatch({type: 'READ_PERFORM', uri, kind, readId});
   }
 
   render() {
@@ -40,7 +39,6 @@ ui.register(['__loading'], ({ element, dispatch}) => {
     <Loading
       kind={element.get('kind').toJS()}
       uri={element.get('uri')}
-      where={element.get('where', 'content')}
       dispatch={dispatch}
       readId={element.get('readId')}/>
   );

--- a/packages/core/src/read/elements/read.js
+++ b/packages/core/src/read/elements/read.js
@@ -12,8 +12,7 @@ class Read extends React.Component {
       React.PropTypes.string,
       React.PropTypes.arrayOf(React.PropTypes.string)
     ]).isRequired,
-    uri: React.PropTypes.string.isRequired,
-    where: React.PropTypes.string.isRequired
+    uri: React.PropTypes.string.isRequired
   };
 
   constructor(props) {
@@ -21,8 +20,8 @@ class Read extends React.Component {
   }
 
   componentDidMount() {
-    const { dispatch, kind, uri, where } = this.props;
-    dispatch({type: 'READ', uri, where, kind});
+    const { dispatch, kind, uri } = this.props;
+    dispatch({type: 'READ', uri, kind});
   }
 
   render() {
@@ -35,7 +34,6 @@ ui.register(['__read'], ({ element, dispatch }) => {
     <Read
       kind={element.get('kind').toJS()}
       uri={element.get('uri')}
-      where={element.get('where', 'content')}
       dispatch={dispatch} />
   );
 });

--- a/packages/core/src/read/reducer.js
+++ b/packages/core/src/read/reducer.js
@@ -48,10 +48,7 @@ export default function(config, cursor, action) {
         .setIn(pathToReadId, uuid());
     }
     case 'READ_SUCCEEDED': {
-      const kind = canonicalKind.size === 1 ? canonicalKind.set(0, '__container') : canonicalKind.rest();
-      return cursor
-        .setIn(pathToKind, kind)
-        .setIn(action.fromPath, apply(fromJS(action.value), childrenElements).value());
+      return cursor.setIn(action.fromPath, apply(fromJS(action.value), childrenElements).value());
     }
     case 'READ_FAILED': {
       const pathToMeta = List.of(...action.fromPath, 'meta');

--- a/packages/core/src/read/reducer.js
+++ b/packages/core/src/read/reducer.js
@@ -49,10 +49,9 @@ export default function(config, cursor, action) {
     }
     case 'READ_SUCCEEDED': {
       const kind = canonicalKind.size === 1 ? canonicalKind.set(0, '__container') : canonicalKind.rest();
-      const pathToWhere = List.of(...action.fromPath, action.where);
       return cursor
         .setIn(pathToKind, kind)
-        .setIn(pathToWhere, apply(fromJS(action.value), childrenElements).value());
+        .setIn(action.fromPath, apply(fromJS(action.value), childrenElements).value());
     }
     case 'READ_FAILED': {
       const pathToMeta = List.of(...action.fromPath, 'meta');


### PR DESCRIPTION
BREAKING: This pull request contains a breaking change for the reads functionality.
* When performing a read, the JSON response overrides the sub-state that initiated the read operation 
* Get rid of the 'where' property of the reads
* Get rid of the 'where' prop of the Loading and Read components