### PR TITLE
Enrichers

### DIFF
--- a/packages/core/src/__tests__/read.js
+++ b/packages/core/src/__tests__/read.js
@@ -1,11 +1,11 @@
 'use strict'
 
-// TODO: this test goes to the core subsystem
 import { mount } from 'enzyme'
 
 import React from 'react'
 import { fromJS } from 'immutable'
-import { ui, read, data, Engine, http } from '..'
+import { ui, enrich, transform, read, data, Engine, http } from '..'
+import * as propNames from '../propNames'
 const { isOfKind } = data.element
 
 describe("Reads using core subsystem's Read element", () => {
@@ -30,6 +30,14 @@ describe("Reads using core subsystem's Read element", () => {
         meta: http.responseMeta({ url: u }),
       })
     )
+
+    transform.register('scene', (scene, { readValue }) =>
+      scene.set('metaUrl', readValue.getIn([propNames.metadata, 'url']))
+    )
+
+    enrich.register('scene', async (scene, { subsystems }) =>
+      scene.set('ss', subsystems.enrich.name)
+    )
   })
 
   afterEach(() => {
@@ -53,7 +61,10 @@ describe("Reads using core subsystem's Read element", () => {
     expect(scenes.length).toBeGreaterThan(0)
 
     const scene = scenes.first()
-    expect(scene.prop('element').get('title')).toEqual('Scene Title')
+    const sceneEl = scene.prop('element')
+    expect(sceneEl.get('title')).toEqual('Scene Title')
+    expect(sceneEl.get('metaUrl')).toEqual('https://netcetera.com/test.json')
+    expect(sceneEl.get('ss')).toEqual('enrich')
   })
 })
 

--- a/packages/core/src/core/index.js
+++ b/packages/core/src/core/index.js
@@ -6,6 +6,7 @@ import * as SubSystem from '../subsystem'
 
 // default subsystems
 
+import enrich from '../enrich'
 import transform from '../transform'
 import read from '../read'
 import effect from '../effect'
@@ -26,7 +27,15 @@ const core = SubSystem.create(() => ({
 /**
  * The list of default subsystems
  */
-export const defaultSubsystems = [transform, read, effect, update, ui, core]
+export const defaultSubsystems = [
+  enrich,
+  transform,
+  read,
+  effect,
+  update,
+  ui,
+  core,
+]
 core.defaultSubsystems = defaultSubsystems
 
 // default registrations

--- a/packages/core/src/data/element.js
+++ b/packages/core/src/data/element.js
@@ -160,9 +160,9 @@ function normalize(kind): ?List<string> {
 }
 
 export function pathsToChildElements(element) {
-  return normalize(element.get('@@girders-elements/children'))
-         .flatMap(childrenPath => element.get(childrenPath).map((_, i) => List.of(childrenPath, i)))
-         .toList();
+  return childPositions(element).flatMap(childrenPath =>
+    element.get(childrenPath).map((_, i) => List.of(childrenPath, i))
+  )
 }
 /**
  * Property name of for the location where positions of the elements'children

--- a/packages/core/src/enrich/__tests__/enrich.js
+++ b/packages/core/src/enrich/__tests__/enrich.js
@@ -1,0 +1,108 @@
+'use strict'
+
+import { fromJS, List } from 'immutable'
+import * as Subsystem from '../../subsystem'
+import * as Kernel from '../../kernel'
+import * as propNames from '../../propNames'
+import * as data from '../../data'
+
+import enrichSubsystem from '..'
+
+const app = Subsystem.create(() => ({
+  name: 'app',
+}))
+
+const { enrich } = app
+
+describe('Enrichers', () => {
+  const appState = {
+    kind: 'c1',
+    [propNames.children]: 'children',
+    data: 1,
+    children: [
+      {
+        kind: 'c1',
+        [propNames.children]: 'children',
+        data: 11,
+
+        children: [
+          {
+            kind: 'c1',
+            data: 111,
+          },
+          {
+            kind: 'c1',
+            data: 112,
+          },
+          {
+            kind: 'c2',
+            items: [1, 2, 3],
+          },
+        ],
+      },
+      {
+        kind: 'c2',
+        items: [10, 20],
+      },
+    ],
+  }
+
+  enrich.register('c1', async el => {
+    await sleep(randomMs(100))
+
+    return el.update('data', data => data + 1000)
+  })
+
+  enrich.register('c1', async el => {
+    await sleep(randomMs(100))
+
+    const sum = el
+      .get('children', List())
+      .filter(data.isOfKind('c1'))
+      .map(el => el.get('data', 0))
+      .reduce((a, b) => a + b, el.get('sum', 0))
+
+    const items = el
+      .get('children', List())
+      .map(el => el.get('items', List()))
+      .reduce((a, b) => a.concat(b), List())
+
+    return el
+      .update('items', i => List(i).concat(items))
+      .update('data', d => d + sum)
+  })
+
+  enrich.register('c2', async el => {
+    await sleep(randomMs(150))
+
+    return el.update('items', items => items.push(100))
+  })
+
+  test('enrichers run concurrently for all children, before the parent', async () => {
+    const kernel = Kernel.create([enrichSubsystem, app], appState, {})
+    const enricher = kernel.subsystems.enrich.buildEnricher()
+
+    const result = await enricher(fromJS(appState))
+
+    expect(result.getIn(['children', 0, 'children', 2, 'items'])).toEqualI(
+      List.of(1, 2, 3, 100)
+    )
+
+    expect(result.getIn(['children', 1, 'items'])).toEqualI(
+      List.of(10, 20, 100)
+    )
+
+    expect(result.getIn(['children', 0, 'children', 0, 'data'])).toEqual(1111)
+    expect(result.getIn(['children', 0, 'data'])).toEqual(1011 + 1111 + 1112)
+    expect(result.getIn(['data'])).toEqual(1011 + 1111 + 1112 + 1001)
+    expect(result.getIn(['items'])).toEqualI(List.of(1, 2, 3, 100, 10, 20, 100))
+  })
+})
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+function randomMs(max) {
+  return Math.trunc(max * Math.random()) + 1
+}

--- a/packages/core/src/enrich/impl.js
+++ b/packages/core/src/enrich/impl.js
@@ -1,0 +1,35 @@
+'use strict'
+
+import { List } from 'immutable'
+import { memoize } from '../impl/util'
+import * as data from '../data'
+
+export function enricher(registry) {
+  const elementEnricher = memoize(kind =>
+    registry
+      .get(kind)
+      .reduce(
+        (f, g) => (x, context) =>
+          Promise.resolve(f(x, context)).then(x => g(x, context)),
+        x => Promise.resolve(x)
+      )
+  )
+
+  async function postWalk(el, context) {
+    const paths = data.pathsToChildElements(el)
+    const changedChildren = List(
+      await Promise.all(paths.map(p => postWalk(el.getIn(p), context)))
+    )
+
+    const enrichments = paths.zip(changedChildren)
+
+    const withModifiedChildren = enrichments.reduce(
+      (el, [path, value]) => el.setIn(path, value),
+      el
+    )
+    const elEnricher = elementEnricher(data.kindOf(withModifiedChildren))
+    return elEnricher(withModifiedChildren, context)
+  }
+
+  return (el, context = {}) => postWalk(el, context)
+}

--- a/packages/core/src/enrich/index.js
+++ b/packages/core/src/enrich/index.js
@@ -1,0 +1,64 @@
+'use strict'
+
+import R from 'ramda'
+import invariant from 'invariant'
+
+import { isElementRef } from '../data'
+
+import * as SubSystem from '../subsystem'
+import { MultivalueRegistry, chainMultivalueRegistries } from '../registry'
+
+import * as impl from './impl'
+
+const registryAttribute = '@@girders-elements/_enrichRegistry'
+
+SubSystem.extend(() => {
+  const registry = new MultivalueRegistry()
+
+  return {
+    enrich: {
+      [registryAttribute]: registry,
+
+      /**
+       * Registers an enricher for the specific kind
+       */
+      register(kind, enricher) {
+        invariant(
+          isElementRef(kind),
+          'You must provide a valid element reference to register'
+        )
+        invariant(
+          enricher != null && typeof enricher === 'function',
+          'You must provide an enricher function'
+        )
+
+        registry.register(kind, enricher)
+      },
+
+      reset() {
+        registry.reset()
+      },
+    },
+  }
+})
+
+export default SubSystem.create(system => ({
+  name: 'enrich',
+
+  buildEnricher() {
+    const combinedRegistry = getCombinedRegistry(system.subsystemSequence)
+
+    if (combinedRegistry == null) {
+      return x => Promise.resolve(x)
+    }
+    return impl.enricher(combinedRegistry)
+  },
+}))
+
+const getRegistry = R.path(['enrich', registryAttribute])
+
+const getCombinedRegistry = R.pipe(
+  R.map(getRegistry),
+  R.reject(R.isNil),
+  chainMultivalueRegistries
+)

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -13,7 +13,7 @@ import * as http from './read/http'
 
 import { Engine, EntryPoint } from './engine'
 
-let { ui, read, effect, update, transform } = core
+let { ui, read, effect, update, transform, enrich } = core
 
 export {
   ui,
@@ -21,6 +21,7 @@ export {
   effect,
   update,
   transform,
+  enrich,
   data,
   zip,
   actions,

--- a/packages/core/src/read/__tests__/read.js
+++ b/packages/core/src/read/__tests__/read.js
@@ -4,6 +4,7 @@ import { List } from 'immutable'
 
 import * as Subsystem from '../../subsystem'
 import * as Kernel from '../../kernel'
+import enrich from '../../enrich'
 import transform from '../../transform'
 import read from '..'
 
@@ -23,7 +24,7 @@ describe('Read Subsytem', () => {
   )
 
   const kernel = Kernel.create(
-    [transform, read, app],
+    [enrich, transform, read, app],
     {
       kind: 'app',
       '@@girders-elements/children': 'content',

--- a/packages/core/src/read/http.js
+++ b/packages/core/src/read/http.js
@@ -33,6 +33,7 @@ function errorResponseForUrl(url): ErrorFn {
   return error => ({
     meta: {
       url,
+      uri: url,
       status: 420,
       message: error,
     },
@@ -46,6 +47,7 @@ export function responseMeta(resp: Object): Meta {
   }
   return {
     url: resp.url,
+    uri: resp.url,
     status: resp.status ? resp.status : 200,
     message: message,
   }

--- a/packages/core/src/read/impl.js
+++ b/packages/core/src/read/impl.js
@@ -1,4 +1,3 @@
-/** @flow */
 'use strict'
 
 import R from 'ramda'
@@ -52,13 +51,12 @@ export const reducer = R.curry(function reducer(config, cursor, action) {
         .setIn(pathToReadId, uuid())
     }
     case 'READ_SUCCEEDED': {
+      const response = fromJS(action.response.value).merge({
+        '@@girders-elements/metadata': action.response.meta,
+      })
       return cursor.setIn(
         fromPath,
-        transformation(
-          fromJS(action.response.value).merge({
-            '@@girders-elements/metadata': action.response.meta,
-          })
-        )
+        transformation(response, { readValue: response })
       )
     }
     case 'READ_FAILED': {
@@ -81,7 +79,7 @@ function readSaga(config) {
 
     const pattern = action.uri
     const revalidate = action.revalidate
-    const reader: ?ReadFn = registry.get(pattern) || registry.get(fallback)
+    const reader = registry.get(pattern) || registry.get(fallback)
     if (reader != null) {
       const readResponse = yield call(reader, pattern, revalidate)
       if (readResponse.value) {

--- a/packages/core/src/read/index.js
+++ b/packages/core/src/read/index.js
@@ -5,6 +5,7 @@ import invariant from 'invariant'
 
 // required subsystems
 import * as SubSystem from '../subsystem'
+import '../enrich'
 import '../transform'
 
 import { PatternRegistry, chainRegistries } from '../registry'
@@ -67,9 +68,10 @@ export default SubSystem.create((system, instantiatedSubsystems) => {
   )
 
   const registry = getCombinedRegistry(system.subsystemSequence)
+  const enrichment = instantiatedSubsystems.enrich.buildEnricher()
   const transformation = instantiatedSubsystems.transform.buildTransformer()
 
-  const config = { registry, transformation }
+  const config = { registry, enrichment, transformation, kernel: system }
 
   // prepare the saga middleware (this may ba a separate subsystem)
   const sagaMiddleware = createSagaMiddleware()

--- a/packages/core/src/registry/__tests__/RegistryChain.js
+++ b/packages/core/src/registry/__tests__/RegistryChain.js
@@ -111,6 +111,13 @@ describe('chainRegistries', () => {
     expect(combined.get('a')).toEqual(3)
     expect(combined.get('b')).toEqual(6)
   })
+
+  it('combines a single registry', () => {
+    const combined = chainRegistries([reg2])
+
+    reg2.register('a', 1)
+    expect(combined.get(['a'])).toEqual(1)
+  })
 })
 
 describe('chainMultivalueRegistries', () => {
@@ -135,5 +142,12 @@ describe('chainMultivalueRegistries', () => {
     reg4.register(['a', 'b'], 4)
 
     expect(combined.get(['a', 'b'])).toEqualI(List.of(1, 2, 3, 4))
+  })
+
+  it('combines a single registry', () => {
+    const combined = chainMultivalueRegistries([reg1])
+
+    reg1.register('a', 1)
+    expect(combined.get(['a'])).toEqualI(List.of(1))
   })
 })

--- a/packages/core/src/transform/__tests__/context.js
+++ b/packages/core/src/transform/__tests__/context.js
@@ -1,0 +1,36 @@
+'use strict'
+
+import { fromJS } from 'immutable'
+
+import * as Subsystem from '../../subsystem'
+import * as Kernel from '../../kernel'
+
+import transformSS from '..'
+
+const app = Subsystem.create(() => ({
+  name: 'app',
+}))
+
+describe('Context passed to transformers', () => {
+  const data = {
+    kind: 'root',
+    value: 'test',
+  }
+
+  const transf = jest.fn()
+  transf.mockImplementation(e => e)
+
+  app.transform.register('root', transf)
+
+  const kernel = Kernel.create([transformSS, app], data, {})
+
+  test('the context object passed to the transformer is available to transformer fns', () => {
+    const transformer = kernel.subsystems.transform.buildTransformer()
+    const context = { uri: 'urn:example' }
+
+    transformer(fromJS(data), context)
+
+    expect(transf).toHaveBeenCalled()
+    expect(transf.mock.calls[0][1]).toEqual(context)
+  })
+})

--- a/packages/core/src/transform/impl.js
+++ b/packages/core/src/transform/impl.js
@@ -5,12 +5,17 @@ import { kindOf } from '../data/element'
 import { memoize } from '../impl/util'
 
 import { postWalk, root, value } from '../zip'
+import { flow } from '../data'
 
 export function transformer(registry, elementZipper) {
-  const elementTransformer = memoize(kind =>
-    registry.get(kind).reduce((f, g) => x => g(f(x)), R.identity)
+  const elementTransformer = memoize(kind => context =>
+    registry
+      .get(kind)
+      .reduce((f, g) => x => g(f(x, context), context), R.identity)
   )
-  const transform = element => elementTransformer(kindOf(element))(element)
 
-  return R.pipe(elementZipper, postWalk(transform), root, value)
+  const transform = context => el => elementTransformer(kindOf(el))(context)(el)
+
+  return (el, context = {}) =>
+    flow(el, elementZipper, postWalk(transform(context)), root, value)
 }

--- a/packages/core/src/transform/impl.js
+++ b/packages/core/src/transform/impl.js
@@ -8,13 +8,13 @@ import { postWalk, root, value } from '../zip'
 import { flow } from '../data'
 
 export function transformer(registry, elementZipper) {
-  const elementTransformer = memoize(kind => context =>
+  const elementTransformer = memoize(kind =>
     registry
       .get(kind)
-      .reduce((f, g) => x => g(f(x, context), context), R.identity)
+      .reduce((f, g) => (x, context) => g(f(x, context), context), R.identity)
   )
 
-  const transform = context => el => elementTransformer(kindOf(el))(context)(el)
+  const transform = context => el => elementTransformer(kindOf(el))(el, context)
 
   return (el, context = {}) =>
     flow(el, elementZipper, postWalk(transform(context)), root, value)


### PR DESCRIPTION
Enrichers allow one to attach async processor to the read pipeline. The enricher is allowed access to all subystems via the `context` object. 

Enrichers run concurrently for all children of a node. 

See tests for details. 