### PR TITLE
avoid logging an error during readRefresh

### DIFF
--- a/packages/core/src/impl/log.js
+++ b/packages/core/src/impl/log.js
@@ -1,6 +1,15 @@
 'use strict'
 
 /* eslint-disable no-console */
+
+function _info(msg) {
+  if (typeof console !== undefined) {
+    if (console.log != null) {
+      console.log(msg)
+    }
+  }
+}
+
 function _warning(msg) {
   if (typeof console !== undefined) {
     if (console.warn != null) {
@@ -23,15 +32,17 @@ function _error(msg, error) {
 
 function _noop() {}
 
-let error, warning
+let info, error, warning
 
 let NODE_ENV = process.env.NODE_ENV
 if (NODE_ENV !== 'production' && NODE_ENV !== 'test') {
+  info = _info
   error = _error
   warning = _warning
 } else {
+  info = _noop
   error = _noop
   warning = _noop
 }
 
-export { error, warning }
+export { info, error, warning }

--- a/packages/core/src/read/impl.js
+++ b/packages/core/src/read/impl.js
@@ -6,7 +6,7 @@ import { fromJS } from 'immutable'
 
 import uuid from 'uuid'
 
-import { error } from '../impl/log'
+import { info, error } from '../impl/log'
 
 import { canonical, flow } from '../data'
 import * as readActions from './actions'
@@ -207,6 +207,8 @@ export async function readRefresh(context, action) {
         readValue: response.value,
       })
     } else {
+      info(`Unsuccessful refreshing (read) ${uri} `, response)
+
       dispatch({
         ...action,
         readId,

--- a/packages/core/src/read/impl.js
+++ b/packages/core/src/read/impl.js
@@ -207,8 +207,6 @@ export async function readRefresh(context, action) {
         readValue: response.value,
       })
     } else {
-      error(`Error while refreshing (read) ${uri} `, response)
-
       dispatch({
         ...action,
         readId,


### PR DESCRIPTION
Currently, when `actions.readRefresh()` is dispatched and results with a failure, an error is logged to the console, which triggers React Native's red screen:

![ge-error](https://user-images.githubusercontent.com/6344196/31865642-5b4429c4-b772-11e7-872e-0451c72107a0.png)

The red screen is not needed since this is not an invalid state. We only need to dispatch an action that will set `refreshing` to `false`.