### PR TITLE
Add warning for unregistered kinds

### DIFF
--- a/packages/core/src/ui/index.js
+++ b/packages/core/src/ui/index.js
@@ -84,7 +84,9 @@ const forElement = runtime => {
   const componentFor = memoize(kind => {
     const C = registry.get(kind)
     if (C != null) return C(runtime)
-    warning(`Couldn't find the following kind(s) within the registry: [${kind.toJS()}]`)
+    warning(
+      `Couldn't find the following kind(s) within the registry: [${kind.toJS()}]`
+    )
     return null
   })
 

--- a/packages/core/src/ui/index.js
+++ b/packages/core/src/ui/index.js
@@ -8,6 +8,7 @@ import React from 'react'
 
 import invariant from 'invariant'
 
+import { warning } from '../impl/log'
 import { Registry, chainRegistries } from '../registry'
 import ElementView from './ElementView'
 import * as data from '../data'
@@ -83,6 +84,7 @@ const forElement = runtime => {
   const componentFor = memoize(kind => {
     const C = registry.get(kind)
     if (C != null) return C(runtime)
+    warning(`Couldn't find the following kind(s) within the registry: [${kind.toJS()}]`)
     return null
   })
 


### PR DESCRIPTION
This will print a proper warning inside the console to warn about missing kinds inside the registry.
Specially if the code base is huge a developer can easily see if the registry is missing some types.

![screen shot 2017-10-23 at 11 31 25](https://user-images.githubusercontent.com/1339576/31884831-bc61d81a-b7ee-11e7-9f83-78aed733efbc.jpg)
