### PR TITLE
Add `failedRefresh` to the  metadata of a refreshed element.

### DIFF
--- a/packages/core/src/read/actions.js
+++ b/packages/core/src/read/actions.js
@@ -4,6 +4,7 @@ export const types = {
   read: '@@girders-elements/actions.read',
   readRefresh: '@@girders-elements/actions.read.refresh',
   setRefreshing: '@@girders-elements/actions.read.setRefreshing',
+  setRefreshMetadata: '@@girders-elements/actions.read.setRefreshMetadata',
   setLoading: '@@girders-elements/actions.read.setLoading',
   apply: '@@girders-elements/actions.read.apply',
   fail: '@@girders-elements/actions.read.fail',

--- a/packages/core/src/read/index.js
+++ b/packages/core/src/read/index.js
@@ -80,6 +80,10 @@ read.effect.forKind([], effects => {
 read.update.forKind([], updates => {
   updates.register(readActions.types.setLoading, impl.setLoading)
   updates.register(readActions.types.setRefreshing, impl.setRefreshing)
+  updates.register(
+    readActions.types.setRefreshMetadata,
+    impl.setRefreshMetadata
+  )
   updates.register(readActions.types.apply, impl.applyRead)
   updates.register(readActions.types.fail, impl.fail)
 })


### PR DESCRIPTION
When a `readRefresh` fails, trace  (the failed read metadata) is left in the element's [propNames.metadata].failedRefresh