### PR TITLE
replace code 420 with 999 for exceptions

### DIFF
--- a/packages/core/src/read/__tests__/http.js
+++ b/packages/core/src/read/__tests__/http.js
@@ -45,13 +45,13 @@ describe('http', () => {
     })
     expect(http.failedResponse('Fail')).toEqual({
       meta: {
-        status: 420,
+        status: 999,
         message: 'Fail',
       },
     })
     expect(http.failedResponse('Fail', 'http://example.com')).toEqual({
       meta: {
-        status: 420,
+        status: 999,
         message: 'Fail',
         uri: 'http://example.com',
         url: 'http://example.com',
@@ -60,7 +60,7 @@ describe('http', () => {
     expect(http.failedResponse('Fail', 42, 'http://example.com')).toEqual({
       value: 42,
       meta: {
-        status: 420,
+        status: 999,
         message: 'Fail',
         uri: 'http://example.com',
         url: 'http://example.com',
@@ -78,7 +78,7 @@ describe('http', () => {
 
       expect(http.flow(http.failedResponse('Fail'), R.inc, R.add(10))).toEqual({
         meta: {
-          status: 420,
+          status: 999,
           message: 'Fail',
         },
       })
@@ -97,7 +97,7 @@ describe('http', () => {
         http.flow(resp, R.inc, () => http.failedResponse('Fail'), R.dec)
       ).toEqual({
         meta: {
-          status: 420,
+          status: 999,
           message: 'Fail',
         },
       })

--- a/packages/core/src/read/http.js
+++ b/packages/core/src/read/http.js
@@ -89,7 +89,7 @@ export function failedResponse(message, object = undefined, from = undefined) {
     ...(object != null ? { value: object } : {}),
     meta: {
       ...(from != null ? { uri: from, url: from } : {}),
-      status: 420,
+      status: 999,
       message,
     },
   }

--- a/packages/core/src/read/impl.js
+++ b/packages/core/src/read/impl.js
@@ -116,7 +116,7 @@ async function performRead(context, readParams) {
       meta: {
         url: uri,
         uri,
-        status: 420,
+        status: 999,
         message: `There's no reader defined for ${pattern}. Did you forget to register a fallback reader?`,
       },
     }
@@ -166,7 +166,7 @@ export async function read(context, action) {
       type: readActions.types.fail,
       response: {
         meta: {
-          status: 420,
+          status: 999,
           message: e.toString(),
           error: e,
         },


### PR DESCRIPTION
420 seems to be used by react-native XHR to report network connectivity problems.

Use 999 to differentiate programming errors from other http progems.