### PR TITLE
Always remeasure layout on content size change

### DIFF
--- a/packages/components/src/viewport/aware/index.js
+++ b/packages/components/src/viewport/aware/index.js
@@ -33,19 +33,10 @@ export default WrappedComponent => {
         return
       }
       if (
-        this.state.componentOffset !== null &&
-        this.state.componentHeight !== null
+        info.shouldMeasureLayout ||
+        this.state.componentOffset === null ||
+        this.state.componentHeight === null
       ) {
-        this.setState({
-          inViewport: Utils.isInViewport(
-            info.viewportOffset,
-            info.viewportHeight,
-            this.state.componentOffset,
-            this.state.componentHeight,
-            this.props.preTriggerRatio
-          ),
-        })
-      } else {
         UIManager.measureLayout(
           this.nodeHandle,
           info.parentHandle,
@@ -65,6 +56,16 @@ export default WrappedComponent => {
               })
           }
         )
+      } else {
+        this.setState({
+          inViewport: Utils.isInViewport(
+            info.viewportOffset,
+            info.viewportHeight,
+            this.state.componentOffset,
+            this.state.componentHeight,
+            this.props.preTriggerRatio
+          ),
+        })
       }
     }
 

--- a/packages/components/src/viewport/aware/index.js
+++ b/packages/components/src/viewport/aware/index.js
@@ -34,8 +34,8 @@ export default WrappedComponent => {
       }
       if (
         info.shouldMeasureLayout ||
-        this.state.componentOffset === null ||
-        this.state.componentHeight === null
+        this.state.componentOffset == null ||
+        this.state.componentHeight == null
       ) {
         UIManager.measureLayout(
           this.nodeHandle,

--- a/packages/components/src/viewport/tracker/__tests__/tracker.js
+++ b/packages/components/src/viewport/tracker/__tests__/tracker.js
@@ -30,6 +30,7 @@ describe('ViewportTracker', () => {
       parentHandle: undefined,
       viewportOffset: 0,
       viewportHeight: 40,
+      shouldMeasureLayout: true,
     })
 
     instance._onScroll({
@@ -45,6 +46,7 @@ describe('ViewportTracker', () => {
       parentHandle: undefined,
       viewportOffset: 15,
       viewportHeight: 40,
+      shouldMeasureLayout: false,
     })
   })
 })

--- a/packages/components/src/viewport/tracker/index.js
+++ b/packages/components/src/viewport/tracker/index.js
@@ -16,15 +16,6 @@ export default class ViewportTracker extends WithEvents(
     this._viewportOffset = 0
   }
 
-  _onScroll = event => {
-    const childOnScroll = React.Children.only(this.props.children).props
-      .onScroll
-    childOnScroll && childOnScroll(event)
-    this._viewportOffset = event.nativeEvent.contentOffset.y
-
-    this._onViewportChange()
-  }
-
   _onLayout = event => {
     const childOnLayout = React.Children.only(this.props.children).props
       .onLayout
@@ -33,18 +24,35 @@ export default class ViewportTracker extends WithEvents(
     this._onViewportChange()
   }
 
-  _onViewportChange = () => {
+  _onContentSizeChange = event => {
+    const childOnContentSizeChange = React.Children.only(this.props.children)
+      .props.onContentSizeChange
+    childOnContentSizeChange && childOnContentSizeChange(event)
+    this._onViewportChange()
+  }
+
+  _onScroll = event => {
+    const childOnScroll = React.Children.only(this.props.children).props
+      .onScroll
+    childOnScroll && childOnScroll(event)
+    this._viewportOffset = event.nativeEvent.contentOffset.y
+    this._onViewportChange(false)
+  }
+
+  _onViewportChange = (shouldMeasureLayout = true) => {
     this.notifyViewportListeners({
       parentHandle: this.nodeHandle,
       viewportOffset: this._viewportOffset,
       viewportHeight: this._viewportHeight,
+      shouldMeasureLayout,
     })
   }
 
   render() {
     return React.cloneElement(React.Children.only(this.props.children), {
-      onScroll: this._onScroll,
       onLayout: this._onLayout,
+      onContentSizeChange: this._onContentSizeChange,
+      onScroll: this._onScroll,
       ref: ref => (this.nodeHandle = findNodeHandle(ref)),
     })
   }


### PR DESCRIPTION
This PR will fix multiple bugs that used to occur because the changes in the size of the tracked component's content (the one wrapped with `Viewport.Tracker`) were ignored.