### PR TITLE
Notify listeners on add

### DIFF
--- a/packages/components/src/shared/WithEvents.js
+++ b/packages/components/src/shared/WithEvents.js
@@ -5,19 +5,21 @@ import PropTypes from 'prop-types'
 const listeners = '@@girders-elements.internal/listeners'
 
 /**
- * A mxin that adds event handling methods to the a react component
+ * A mixin that adds event handling methods to a React component
  *
- * @param eventDefinitons an array of event definitions or a single event definitions
+ * @param eventDefinitons an array of event definitions or a single event definition
  * @param OriginalComponent
  *
- * an event defintion is either
+ * an event definition is either
  * - a string, representing the event name
  * - an object with the following properties:
  *   - name: the event name (required)
- *   - isChildContext: whether the event should be exposed in childContext
+ *   - inChildContext: whether the event should be exposed in childContext
+ *     defaults to false
+ *   - notifiesWithLastEventOnAdd: whether the listeners are invoked when added
  *     defaults to false
  *   - addMethod: name of the add listener method (optional)
- *   - removeMethod: name of the remove istener method (optional)
+ *   - removeMethod: name of the remove listener method (optional)
  *   - notifyMethod: name of the notify listeners method (optional)
  */
 export default (eventDefinitons, OriginalComponent) => {
@@ -68,7 +70,7 @@ export default (eventDefinitons, OriginalComponent) => {
     Derived.prototype[d.addMethod] = function(callback) {
       if (this[listeners][d.name].indexOf(callback === -1)) {
         this[listeners][d.name].push(callback)
-        this.lastEvt && callback(this.lastEvt)
+        d.notifiesWithLastEventOnAdd && this.lastEvt && callback(this.lastEvt)
       }
     }
 
@@ -115,6 +117,7 @@ function normalizeEventDefinitions(eventDefs) {
 
   defs = defs.map(d => ({
     inChildContext: false,
+    notifiesWithLastEventOnAdd: false,
     addMethod: `add${d.name}Listener`,
     removeMethod: `remove${d.name}Listener`,
     notifyMethod: `notify${d.name}Listeners`,

--- a/packages/components/src/shared/WithEvents.js
+++ b/packages/components/src/shared/WithEvents.js
@@ -68,6 +68,7 @@ export default (eventDefinitons, OriginalComponent) => {
     Derived.prototype[d.addMethod] = function(callback) {
       if (this[listeners][d.name].indexOf(callback === -1)) {
         this[listeners][d.name].push(callback)
+        this.lastEvt && callback(this.lastEvt)
       }
     }
 
@@ -80,6 +81,7 @@ export default (eventDefinitons, OriginalComponent) => {
 
     Derived.prototype[d.notifyMethod] = function(evt) {
       this[listeners][d.name].forEach(callback => callback(evt))
+      this.lastEvt = evt
     }
   })
 

--- a/packages/components/src/shared/WithEvents.js
+++ b/packages/components/src/shared/WithEvents.js
@@ -25,6 +25,7 @@ const listeners = '@@girders-elements.internal/listeners'
 export default (eventDefinitons, OriginalComponent) => {
   const defs = normalizeEventDefinitions(eventDefinitons)
   const inChildContext = defs.filter(d => d.inChildContext)
+  let lastEvent = null
 
   class Derived extends OriginalComponent {
     constructor(props, context) {
@@ -70,7 +71,7 @@ export default (eventDefinitons, OriginalComponent) => {
     Derived.prototype[d.addMethod] = function(callback) {
       if (this[listeners][d.name].indexOf(callback === -1)) {
         this[listeners][d.name].push(callback)
-        d.notifiesWithLastEventOnAdd && this.lastEvt && callback(this.lastEvt)
+        d.notifiesWithLastEventOnAdd && lastEvent && callback(lastEvent)
       }
     }
 
@@ -83,7 +84,7 @@ export default (eventDefinitons, OriginalComponent) => {
 
     Derived.prototype[d.notifyMethod] = function(evt) {
       this[listeners][d.name].forEach(callback => callback(evt))
-      this.lastEvt = evt
+      lastEvent = evt
     }
   })
 

--- a/packages/components/src/viewport/aware/index.js
+++ b/packages/components/src/viewport/aware/index.js
@@ -28,7 +28,8 @@ export default WrappedComponent => {
       this._isMounted = false
     }
 
-    _onViewportChange = info => {
+    _onViewportChange = (info = this._lastInfo) => {
+      this._lastInfo = info
       if (!this.nodeHandle) {
         return
       }
@@ -37,6 +38,9 @@ export default WrappedComponent => {
         this.state.componentOffset == null ||
         this.state.componentHeight == null
       ) {
+        if (!this._isMounted) {
+          return setTimeout(() => this._onViewportChange(), 50)
+        }
         UIManager.measureLayout(
           this.nodeHandle,
           info.parentHandle,

--- a/packages/components/src/viewport/aware/index.js
+++ b/packages/components/src/viewport/aware/index.js
@@ -20,6 +20,8 @@ export default WrappedComponent => {
       this.context.addViewportListener &&
         this.context.addViewportListener(this._onViewportChange)
       this._isMounted = true
+      this._lastInfo &&
+        setTimeout(() => this._onViewportChange(this._lastInfo), 50)
     }
 
     componentWillUnmount() {
@@ -28,7 +30,7 @@ export default WrappedComponent => {
       this._isMounted = false
     }
 
-    _onViewportChange = (info = this._lastInfo) => {
+    _onViewportChange = info => {
       this._lastInfo = info
       if (!this.nodeHandle) {
         return
@@ -38,28 +40,26 @@ export default WrappedComponent => {
         this.state.componentOffset == null ||
         this.state.componentHeight == null
       ) {
-        if (!this._isMounted) {
-          return setTimeout(() => this._onViewportChange(), 50)
-        }
-        UIManager.measureLayout(
-          this.nodeHandle,
-          info.parentHandle,
-          () => {},
-          (offsetX, offsetY, width, height) => {
-            this._isMounted &&
-              this.setState({
-                componentOffset: offsetY,
-                componentHeight: height,
-                inViewport: Utils.isInViewport(
-                  info.viewportOffset,
-                  info.viewportHeight,
-                  offsetY,
-                  height,
-                  this.props.preTriggerRatio
-                ),
-              })
-          }
-        )
+        this._isMounted &&
+          UIManager.measureLayout(
+            this.nodeHandle,
+            info.parentHandle,
+            () => {},
+            (offsetX, offsetY, width, height) => {
+              this._isMounted &&
+                this.setState({
+                  componentOffset: offsetY,
+                  componentHeight: height,
+                  inViewport: Utils.isInViewport(
+                    info.viewportOffset,
+                    info.viewportHeight,
+                    offsetY,
+                    height,
+                    this.props.preTriggerRatio
+                  ),
+                })
+            }
+          )
       } else {
         this.setState({
           inViewport: Utils.isInViewport(

--- a/packages/components/src/viewport/tracker/__tests__/tracker.js
+++ b/packages/components/src/viewport/tracker/__tests__/tracker.js
@@ -16,6 +16,7 @@ describe('ViewportTracker', () => {
     const cb = jest.fn()
 
     instance.addViewportListener(cb)
+    instance.nodeHandle = 42
 
     instance._onLayout({
       nativeEvent: {
@@ -27,7 +28,7 @@ describe('ViewportTracker', () => {
     })
 
     expect(cb).toHaveBeenLastCalledWith({
-      parentHandle: undefined,
+      parentHandle: 42,
       viewportOffset: 0,
       viewportHeight: 40,
       shouldMeasureLayout: true,
@@ -43,7 +44,7 @@ describe('ViewportTracker', () => {
     })
 
     expect(cb).toHaveBeenLastCalledWith({
-      parentHandle: undefined,
+      parentHandle: 42,
       viewportOffset: 15,
       viewportHeight: 40,
       shouldMeasureLayout: false,

--- a/packages/components/src/viewport/tracker/index.js
+++ b/packages/components/src/viewport/tracker/index.js
@@ -7,7 +7,7 @@ import { findNodeHandle } from 'react-native'
 import WithEvents from '../../shared/WithEvents'
 
 export default class ViewportTracker extends WithEvents(
-  { name: 'viewport', inChildContext: true },
+  { name: 'viewport', inChildContext: true, notifiesWithLastEventOnAdd: true },
   React.Component
 ) {
   constructor(props, context) {

--- a/packages/components/src/viewport/tracker/index.js
+++ b/packages/components/src/viewport/tracker/index.js
@@ -46,12 +46,14 @@ export default class ViewportTracker extends WithEvents(
   }
 
   _onViewportChange = (shouldMeasureLayout = true) => {
-    this.notifyViewportListeners({
-      parentHandle: this.nodeHandle,
-      viewportOffset: this._viewportOffset,
-      viewportHeight: this._viewportHeight,
-      shouldMeasureLayout,
-    })
+    this.nodeHandle &&
+      this._viewportHeight > 0 &&
+      this.notifyViewportListeners({
+        parentHandle: this.nodeHandle,
+        viewportOffset: this._viewportOffset,
+        viewportHeight: this._viewportHeight,
+        shouldMeasureLayout,
+      })
   }
 
   render() {


### PR DESCRIPTION
This PR will:
- Include notification of listeners upon listener add in `WithEvents.js`
- Make sure `ViewportTracker` does not notify listeners with incomplete event data
- Enable `ViewportAware` to reattempt layout measurement in case one was requested while the component has not yet been mounted