### PR TITLE
feat(core): read.perform()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
 language: node_js
 
-before_install:
-  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.1.0
-  - export PATH=$HOME/.yarn/bin:$PATH
-
 cache:
   yarn: true
 

--- a/packages/core/src/read/__tests__/http.js
+++ b/packages/core/src/read/__tests__/http.js
@@ -109,7 +109,6 @@ describe('http', () => {
       fetch.mockReject()
 
       const response = await http.get('http://example.com')
-      console.log(response)
       expect(response.meta.status).toEqual(998)
     })
   })

--- a/packages/core/src/read/__tests__/read.js
+++ b/packages/core/src/read/__tests__/read.js
@@ -281,8 +281,6 @@ describe('Performing reads manually', async () => {
     expect.anything() // the context
   )
 
-  console.log(result)
-
   expect(result.value.get('title')).toEqual('Scene Title X')
   expect(result.value.getIn([propNames.metadata, 'uri'])).toEqual(
     'https://netcetera.com/test.json'

--- a/packages/core/src/read/impl.js
+++ b/packages/core/src/read/impl.js
@@ -81,7 +81,7 @@ export function fail(element, action) {
   )
 }
 
-async function performRead(context, readParams) {
+export async function performRead(context, readParams) {
   const {
     registry,
     enrichment,

--- a/packages/core/src/read/index.js
+++ b/packages/core/src/read/index.js
@@ -69,6 +69,16 @@ const read = SubSystem.create((system, instantiatedSubsystems) => {
   return {
     name: 'read',
     context: config,
+
+    /**
+     * Executes a read using the running system's configuration.
+     *
+     * @param uri the URI to read
+     * @param opts the options as per the reader fn
+     *
+     * @returns Promise<ReadResponse> the read response
+     */
+    perform: (uri, opts = {}) => impl.performRead(system, { uri, opts }),
   }
 })
 


### PR DESCRIPTION
This pull request exposes a `perform` method in the read system that allows you to fetch (read) content using the system's current configuration (registered readers, transformers, etc.)

The API is is with a similar signature of a reader:

```javascript
perform :: (uri, opts) => Promise<ReadResponse>
```

The method is available in the running system's read subsystem:

```javascript
const kernel = Kernel.create(...)
const val = await kernel.subsystems.read.perform(uri)
```

Consequently, the method is available via the context  param to effects, etc.