### PR TITLE
Enhancers (an alternative to Enrichers)

### DIFF
--- a/packages/core/src/__tests__/read.js
+++ b/packages/core/src/__tests__/read.js
@@ -4,7 +4,7 @@ import { mount } from 'enzyme'
 
 import React from 'react'
 import { fromJS } from 'immutable'
-import { ui, enrich, transform, read, data, Engine, http } from '..'
+import { ui, enrich, enhance, transform, read, data, Engine, http } from '..'
 import * as propNames from '../propNames'
 const { isOfKind } = data.element
 
@@ -39,6 +39,11 @@ describe("Reads using core subsystem's Read element", () => {
       await sleep(55)
       return scene.set('ss', context.subsystems.enrich.name)
     })
+
+    enhance.register('scene', async (scene, context) => {
+      await sleep(66)
+      return scene => scene.set('ss-enhance', context.subsystems.enhance.name)
+    })
   })
 
   afterEach(() => {
@@ -68,6 +73,7 @@ describe("Reads using core subsystem's Read element", () => {
     expect(sceneEl.get('title')).toEqual('Scene Title')
     expect(sceneEl.get('metaUrl')).toEqual('https://netcetera.com/test.json')
     expect(sceneEl.get('ss')).toEqual('enrich')
+    expect(sceneEl.get('ss-enhance')).toEqual('enhance')
   })
 })
 

--- a/packages/core/src/__tests__/read.js
+++ b/packages/core/src/__tests__/read.js
@@ -42,7 +42,7 @@ describe("Reads using core subsystem's Read element", () => {
 
     enhance.register('scene', async (scene, context) => {
       await sleep(66)
-      return scene => scene.set('ss-enhance', context.subsystems.enhance.name)
+      return s => s.set('ss-enhance', context.subsystems.enhance.name)
     })
   })
 

--- a/packages/core/src/core/index.js
+++ b/packages/core/src/core/index.js
@@ -7,6 +7,7 @@ import * as SubSystem from '../subsystem'
 // default subsystems
 
 import enrich from '../enrich'
+import enhance from '../enhance'
 import transform from '../transform'
 import read from '../read'
 import effect from '../effect'
@@ -29,6 +30,7 @@ const core = SubSystem.create(() => ({
  */
 export const defaultSubsystems = [
   enrich,
+  enhance,
   transform,
   effect,
   update,

--- a/packages/core/src/enhance/__tests__/enhance.js
+++ b/packages/core/src/enhance/__tests__/enhance.js
@@ -1,0 +1,75 @@
+'use strict'
+
+import { fromJS, List } from 'immutable'
+import * as SubSystem from '../../subsystem'
+import * as Kernel from '../../kernel'
+import * as propNames from '../../propNames'
+import * as data from '../../data'
+
+import enhanceSubsystem from '..'
+
+const app = SubSystem.create(() => ({
+  name: 'app',
+}))
+
+const { enhance } = app
+
+describe('Enhancers', () => {
+  const appState = {
+    kind: 'document',
+    [propNames.children]: 'children',
+    data: 1,
+    items: [1, 2, 3],
+    children: [
+      {
+        kind: 'teaser',
+        data: 10,
+      },
+      {
+        kind: 'teaser',
+        data: 20,
+      },
+    ],
+  }
+
+  const incrementData = async el => {
+    await sleep(randomMs(100))
+
+    return el => el.update('data', d => d + 1)
+  }
+
+  enhance.register('document', incrementData)
+  enhance.register('teaser', incrementData)
+
+  test('enhancers should run only for root element', async () => {
+    const kernel = Kernel.create([enhanceSubsystem, app], appState, {})
+    const enhancer = kernel.subsystems.enhance.buildEnhancer()
+
+    const result = await enhancer(fromJS(appState))
+
+    expect(result.get('data')).toEqualI(2)
+    expect(result.getIn(['children', 0, 'data'])).toEqualI(10)
+    expect(result.getIn(['children', 1, 'data'])).toEqualI(20)
+  })
+
+  const appendItem = item => async el => {
+    await sleep(randomMs(100))
+
+    return el => el.update('items', items => items.concat(item))
+  }
+
+  enhance.register(['document'], appendItem(10))
+  enhance.register(['document'], appendItem(100))
+
+  test('enhancers should apply all registered enhancments', async () => {
+    const kernel = Kernel.create([enhanceSubsystem, app], appState, {})
+    const enhancer = kernel.subsystems.enhance.buildEnhancer()
+
+    const result = await enhancer(fromJS(appState))
+
+    expect(result.get('items')).toEqualI(List.of(1, 2, 3, 10, 100))
+  })
+})
+
+const sleep = ms => new Promise(resolve => setTimeout(resolve, ms))
+const randomMs = max => Math.trunc(max * Math.random()) + 1

--- a/packages/core/src/enhance/impl.js
+++ b/packages/core/src/enhance/impl.js
@@ -1,0 +1,30 @@
+'use strict'
+
+import R from 'ramda'
+import { memoize } from '../impl/util'
+import * as data from '../data'
+import * as zip from '../zip'
+
+export function enhancer(config) {
+  const { registry, elementZipper } = config
+
+  const enhancersForKind = memoize(kind => {
+    const enhancers = registry.get(kind)
+    return enhancers.isEmpty() ? null : enhancers
+  })
+
+  async function enhance(loc, context) {
+    const enhancers = data.flow(loc, zip.value, data.kindOf, enhancersForKind)
+    if (enhancers != null) {
+      const el = zip.value(loc)
+      const updates = await Promise.all(enhancers.map(e => e(el, context)))
+      const enhancedValue = R.reduce((v, u) => u(v), el, updates)
+      loc = zip.replace(enhancedValue, loc)
+    }
+
+    return loc
+  }
+
+  return async (el, context = {}) =>
+    zip.value(await enhance(elementZipper(el), context))
+}

--- a/packages/core/src/enhance/index.js
+++ b/packages/core/src/enhance/index.js
@@ -20,7 +20,7 @@ SubSystem.extend(() => {
       [registryAttribute]: registry,
 
       /**
-       * Registers an enhaner for the specific kind
+       * Registers an enhancer for the specific kind
        */
       register(kind, enhancer) {
         invariant(

--- a/packages/core/src/enhance/index.js
+++ b/packages/core/src/enhance/index.js
@@ -1,0 +1,67 @@
+'use strict'
+
+import R from 'ramda'
+import invariant from 'invariant'
+
+import { isElementRef } from '../data'
+
+import * as SubSystem from '../subsystem'
+import { MultivalueRegistry, chainMultivalueRegistries } from '../registry'
+
+import * as impl from './impl'
+
+const registryAttribute = '@@girders-elements/_enhanceRegistry'
+
+SubSystem.extend(() => {
+  const registry = new MultivalueRegistry()
+
+  return {
+    enhance: {
+      [registryAttribute]: registry,
+
+      /**
+       * Registers an enhaner for the specific kind
+       */
+      register(kind, enhancer) {
+        invariant(
+          isElementRef(kind),
+          'You must provide a valid element reference to register'
+        )
+        invariant(
+          enhancer != null && typeof enhancer === 'function',
+          'You must provide an enhancer function'
+        )
+
+        registry.register(kind, enhancer)
+      },
+
+      reset() {
+        registry.reset()
+      },
+    },
+  }
+})
+
+export default SubSystem.create(system => ({
+  name: 'enhance',
+
+  buildEnhancer() {
+    const combinedRegistry = getCombinedRegistry(system.subsystemSequence)
+
+    if (combinedRegistry == null) {
+      return x => Promise.resolve(x)
+    }
+    return impl.enhancer({
+      registry: combinedRegistry,
+      elementZipper: system.elementZipper,
+    })
+  },
+}))
+
+const getRegistry = R.path(['enhance', registryAttribute])
+
+const getCombinedRegistry = R.pipe(
+  R.map(getRegistry),
+  R.reject(R.isNil),
+  chainMultivalueRegistries
+)

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -17,7 +17,7 @@ import * as effectActions from './effect/actions'
 
 import { Engine, EntryPoint } from './engine'
 
-let { ui, read, effect, update, transform, enrich } = core
+let { ui, read, effect, update, transform, enrich, enhance } = core
 
 let actions = {
   types: {
@@ -36,6 +36,7 @@ export {
   update,
   transform,
   enrich,
+  enhance,
   data,
   zip,
   actions,

--- a/packages/core/src/read/__tests__/read.js
+++ b/packages/core/src/read/__tests__/read.js
@@ -5,6 +5,7 @@ import { List } from 'immutable'
 import * as Subsystem from '../../subsystem'
 import * as Kernel from '../../kernel'
 import enrich from '../../enrich'
+import enhance from '../../enhance'
 import transform from '../../transform'
 import update from '../../update'
 import effect from '../../effect'
@@ -29,7 +30,7 @@ describe('Read Subsytem', () => {
   app.read.register(/failure.json$/, () => Promise.reject(new Error('fail')))
 
   const kernel = Kernel.create(
-    [enrich, transform, effect, update, read, app],
+    [enrich, enhance, transform, effect, update, read, app],
     {
       kind: 'app',
       [propNames.children]: ['content', 'failure'],
@@ -106,7 +107,7 @@ describe('Read function', () => {
   app.read.register(/test.json$/, readFn)
 
   const kernel = Kernel.create(
-    [enrich, transform, effect, update, read, app],
+    [enrich, enhance, transform, effect, update, read, app],
     {
       kind: 'app',
       [propNames.children]: ['content'],
@@ -177,16 +178,19 @@ describe('Refreshing', () => {
     refresher.mockClear()
   })
 
-  const kernel = Kernel.create([enrich, transform, effect, update, read, app], {
-    kind: 'app',
-    [propNames.children]: ['content'],
+  const kernel = Kernel.create(
+    [enrich, enhance, transform, effect, update, read, app],
+    {
+      kind: 'app',
+      [propNames.children]: ['content'],
 
-    content: {
-      kind: ['__read', 'scene'],
-      uri: 'https://netcetera.com/test.json',
-      revalidate: true,
-    },
-  })
+      content: {
+        kind: ['__read', 'scene'],
+        uri: 'https://netcetera.com/test.json',
+        revalidate: true,
+      },
+    }
+  )
 
   test('refresh', async () => {
     let content = kernel.query(['content'])
@@ -263,9 +267,12 @@ describe('Performing reads manually', async () => {
 
   app.read.register(/test.json$/, readFn)
 
-  const kernel = Kernel.create([enrich, transform, effect, update, read, app], {
-    kind: 'app',
-  })
+  const kernel = Kernel.create(
+    [enrich, enhance, transform, effect, update, read, app],
+    {
+      kind: 'app',
+    }
+  )
 
   const result = await kernel.subsystems.read.perform(
     'https://netcetera.com/test.json',

--- a/packages/core/src/read/impl.js
+++ b/packages/core/src/read/impl.js
@@ -85,6 +85,7 @@ export async function performRead(context, readParams) {
   const {
     registry,
     enrichment,
+    enhancement,
     transformation,
   } = context.subsystems.read.context
 
@@ -119,13 +120,23 @@ export async function performRead(context, readParams) {
 
       const enrichedResponse = await enrichment(readValue, enrichContext)
 
-      const transformContext = {
+      const enhanceContext = {
         ...enrichContext,
         readValue: enrichedResponse,
       }
 
-      const transformedResponse = transformation(
+      const enhancedResponse = await enhancement(
         enrichedResponse,
+        enhanceContext
+      )
+
+      const transformContext = {
+        ...enhanceContext,
+        readValue: enhancedResponse,
+      }
+
+      const transformedResponse = transformation(
+        enhancedResponse,
         transformContext
       )
 

--- a/packages/core/src/read/impl.js
+++ b/packages/core/src/read/impl.js
@@ -119,18 +119,15 @@ export async function performRead(context, readParams) {
 
       const enhancedResponse = await enhancement(readValue, enhanceContext)
 
-      const enrichedContext = {
+      const enrichContext = {
         ...enhanceContext,
         readValue: enhancedResponse,
       }
 
-      const enrichedResponse = await enrichment(
-        enhancedResponse,
-        enrichedContext
-      )
+      const enrichedResponse = await enrichment(enhancedResponse, enrichContext)
 
       const transformContext = {
-        ...enrichedContext,
+        ...enrichContext,
         readValue: enrichedResponse,
       }
 

--- a/packages/core/src/read/impl.js
+++ b/packages/core/src/read/impl.js
@@ -39,7 +39,6 @@ export function setLoading(element, action) {
     updateKind(k => k.set(0, '__loading')),
     setReadId(readId)
   )
-  return final
 }
 
 export function setRefreshing(element, action) {
@@ -111,32 +110,32 @@ export async function performRead(context, readParams) {
         [propNames.metadata]: fromJS(readResponse.meta || defaultMeta(uri)),
       })
 
-      const enrichContext = {
+      const enhanceContext = {
         readValue,
         config: kernel.config,
         subsystems: kernel.subsystems,
         subsystemSequence: kernel.subsystemSequence,
       }
 
-      const enrichedResponse = await enrichment(readValue, enrichContext)
+      const enhancedResponse = await enhancement(readValue, enhanceContext)
 
-      const enhanceContext = {
-        ...enrichContext,
-        readValue: enrichedResponse,
-      }
-
-      const enhancedResponse = await enhancement(
-        enrichedResponse,
-        enhanceContext
-      )
-
-      const transformContext = {
+      const enrichedContext = {
         ...enhanceContext,
         readValue: enhancedResponse,
       }
 
-      const transformedResponse = transformation(
+      const enrichedResponse = await enrichment(
         enhancedResponse,
+        enrichedContext
+      )
+
+      const transformContext = {
+        ...enrichedContext,
+        readValue: enrichedResponse,
+      }
+
+      const transformedResponse = transformation(
+        enrichedResponse,
         transformContext
       )
 

--- a/packages/core/src/read/index.js
+++ b/packages/core/src/read/index.js
@@ -8,6 +8,7 @@ import * as SubSystem from '../subsystem'
 import '../update'
 import '../effect'
 import '../enrich'
+import '../enhance'
 import '../transform'
 
 import { PatternRegistry, chainRegistries } from '../registry'
@@ -62,9 +63,16 @@ const read = SubSystem.create((system, instantiatedSubsystems) => {
 
   const registry = getCombinedRegistry(system.subsystemSequence)
   const enrichment = instantiatedSubsystems.enrich.buildEnricher()
+  const enhancement = instantiatedSubsystems.enhance.buildEnhancer()
   const transformation = instantiatedSubsystems.transform.buildTransformer()
 
-  const config = { registry, enrichment, transformation, kernel: system }
+  const config = {
+    registry,
+    enrichment,
+    enhancement,
+    transformation,
+    kernel: system,
+  }
 
   return {
     name: 'read',


### PR DESCRIPTION
Implement *enhancers* as an alternative to *enrichers*.

Profiling showed that there is a significant performance impact of using enrichers mostly due to the inefficient Promise implementation present in react native. Enhancers are a solution (probably a temporary one) that should perform better.

Enhancers, like enrichers are registered for a specific element, but they will be only allowed to act on root level elements.

Enhancers have the API
```javascript
// registration
enhance.register(kind, enhancer)

// enhancer signature
enhancer :: async (el, context) => (el => el)
```

In other words, they take the element, an optional context and then return an updating fn that will eventually apply the enhancement to the element in question.

All enhancers are run in parallel on the read document. The order in which the returned update fns are run is determined by the subsystem sequence / registration sequence.

The idea is that the enhancer performs necessary async / fetch operations in the body of the async call (by examining the provided document), once everything is ready it returns the update fn which will apply the changes on the document.

e.g.

```javascript
enhance.register(['document'], async (el, context) => {
  const bookmarks = await getBookmarks(context)

  return document => applyBookmarks(document)
})
```

Closes #84