### PR TITLE
feat(core): Implement reduce for zippers

### DIFF
--- a/packages/core/src/data/index.js
+++ b/packages/core/src/data/index.js
@@ -10,3 +10,8 @@ export { element } // deprecated use
  * Like R.pipe, but the composition is immediately executed using the first arg.
  */
 export const flow = (v, ...fs) => R.reduce((x, f) => f(x), v, fs)
+
+/**
+ * when for reduce
+ */
+export const when = (pred, fn) => (acc, i) => (pred(i) ? fn(acc, i) : acc)

--- a/packages/core/src/zip/__tests__/reduce.js
+++ b/packages/core/src/zip/__tests__/reduce.js
@@ -1,0 +1,123 @@
+'use strict'
+
+import { fromJS, List } from 'immutable'
+import * as zip from '..'
+import * as data from '../../data'
+
+describe('Reducing a Zipper', () => {
+  const organization = {
+    kind: 'pm',
+    name: 'alex',
+    children: [
+      {
+        kind: 'tc',
+        name: 'zdravko',
+        children: [
+          {
+            kind: 'tm',
+            name: 'emilija',
+          },
+          {
+            kind: 'tm',
+            name: 'filip',
+          },
+        ],
+      },
+      {
+        kind: 'tc',
+        name: 'andon',
+        children: [
+          {
+            kind: 'tm',
+            name: 'blagoja',
+          },
+          {
+            kind: 'tm',
+            name: 'goran',
+          },
+        ],
+      },
+      {
+        kind: 'tc',
+        name: 'ognen',
+      },
+    ],
+  }
+  const organizationElement = fromJS(organization)
+
+  it('can be done in post-order fashion', () => {
+    // given
+    const elementZipper = zip.elementZipper({
+      defaultChildPositions: 'children',
+    })(organizationElement)
+
+    // when
+    const result = zip.reduce(
+      (acc, item) => (item.get('name') ? acc.push(item.get('name')) : acc),
+      List(),
+      elementZipper
+    )
+
+    // then
+    expect(result).toEqualI(
+      List.of(
+        'emilija',
+        'filip',
+        'zdravko',
+        'blagoja',
+        'goran',
+        'andon',
+        'ognen',
+        'alex'
+      )
+    )
+  })
+
+  it('can be done in pre-order fashion', () => {
+    // given
+    const elementZipper = zip.elementZipper({
+      defaultChildPositions: 'children',
+    })(organizationElement)
+
+    // when
+    const result = zip.reducePre(
+      (acc, item) => (item.get('name') ? acc.push(item.get('name')) : acc),
+      List(),
+      elementZipper
+    )
+
+    // then
+    expect(result).toEqualI(
+      List.of(
+        'alex',
+        'zdravko',
+        'emilija',
+        'filip',
+        'andon',
+        'blagoja',
+        'goran',
+        'ognen'
+      )
+    )
+  })
+
+  it('can be done using a predicate', () => {
+    // given
+    const elementZipper = zip.elementZipper({
+      defaultChildPositions: 'children',
+    })(organizationElement)
+
+    // when
+    const result = zip.reduce(
+      data.when(
+        item => item.get('kind') === 'tm',
+        (acc, item) => acc.push(item.get('name'))
+      ),
+      List(),
+      elementZipper
+    )
+
+    // then
+    expect(result).toEqualI(List.of('emilija', 'filip', 'blagoja', 'goran'))
+  })
+})

--- a/packages/core/src/zip/index.js
+++ b/packages/core/src/zip/index.js
@@ -3,3 +3,4 @@
 export * from '../vendor/zippa'
 
 export { default as elementZipper } from './elementZipper'
+export * from './reduce'

--- a/packages/core/src/zip/reduce.js
+++ b/packages/core/src/zip/reduce.js
@@ -1,0 +1,11 @@
+'use strict'
+
+import { onPre, onPost, visit } from '../vendor/zippa'
+
+const reduceVisitor = fn => (item, state) => ({ state: fn(state, item) })
+
+export const reduce = (fn, initialAcc, zipper) =>
+  visit([onPost(reduceVisitor(fn))], initialAcc, zipper).state
+
+export const reducePre = (fn, initialAcc, zipper) =>
+  visit([onPre(reduceVisitor(fn))], initialAcc, zipper).state

--- a/packages/core/src/zip/reduce.js
+++ b/packages/core/src/zip/reduce.js
@@ -1,11 +1,16 @@
 'use strict'
 
+import { curry } from 'ramda'
 import { onPre, onPost, visit } from '../vendor/zippa'
 
 const reduceVisitor = fn => (item, state) => ({ state: fn(state, item) })
 
-export const reduce = (fn, initialAcc, zipper) =>
-  visit([onPost(reduceVisitor(fn))], initialAcc, zipper).state
+export const reduce = curry(
+  (fn, initialAcc, zipper) =>
+    visit([onPost(reduceVisitor(fn))], initialAcc, zipper).state
+)
 
-export const reducePre = (fn, initialAcc, zipper) =>
-  visit([onPre(reduceVisitor(fn))], initialAcc, zipper).state
+export const reducePre = curry(
+  (fn, initialAcc, zipper) =>
+    visit([onPre(reduceVisitor(fn))], initialAcc, zipper).state
+)


### PR DESCRIPTION
Adds the following methods in `zip` (they are curried):
```javascript
declare function reduce<T>(
  fn: (acc: T, item: any) => T,
  initialAcc: T,
  zipper: Zipper
): T
```
```javascript
declare function reducePre<T>(
  fn: (acc: T, item: any) => T,
  initialAcc: T,
  zipper: Zipper
): T
```
These functions preform a reduction of the zipper tree in post (`reduce`) or pre (`reducePre`) order.

Also, the following method is added in `data`:
```javascript
declare function when<T>(
  pred: (item: any) => Boolean),
  fn: (acc: T, item: any) => T
): (acc: T, item:any) => T
```
It helps writing zip reducing using a predicate.

Closes https://github.com/netceteragroup/girders-elements/issues/82