### PR TITLE
Implement zip.editCond

### DIFF
--- a/packages/core/src/zip/__tests__/edit.js
+++ b/packages/core/src/zip/__tests__/edit.js
@@ -1,0 +1,109 @@
+'use strict'
+
+import { fromJS } from 'immutable'
+import * as zip from '..'
+
+describe('Editing a Zipper', () => {
+  const organization = {
+    kind: 'pm',
+    name: 'alex',
+    children: [
+      {
+        kind: 'tc',
+        name: 'zdravko',
+        children: [
+          {
+            kind: 'tm',
+            name: 'emilija',
+          },
+          {
+            kind: 'tm',
+            name: 'filip',
+          },
+        ],
+      },
+      {
+        kind: 'tc',
+        name: 'andon',
+        children: [
+          {
+            kind: 'tm',
+            name: 'blagoja',
+          },
+          {
+            kind: 'tm',
+            name: 'goran',
+          },
+        ],
+      },
+      {
+        kind: 'tc',
+        name: 'ognen',
+      },
+    ],
+  }
+
+  const createElementZipper = () =>
+    zip.elementZipper({
+      defaultChildPositions: 'children',
+    })(fromJS(organization))
+
+  it('can be done using conditions (zip.editCond)', () => {
+    // given
+    const elementZipper = createElementZipper()
+
+    // when
+    const result = zip.editCond(
+      [
+        [
+          item => item.get('name') === 'andon',
+          item => item.set('name', 'sikavica'),
+        ],
+        ['tm', item => item.update('name', name => `member-${name}`)],
+      ],
+      elementZipper
+    )
+
+    // then
+    expect(result.value()).toEqualI(
+      fromJS({
+        kind: 'pm',
+        name: 'alex',
+        children: [
+          {
+            kind: 'tc',
+            name: 'zdravko',
+            children: [
+              {
+                kind: 'tm',
+                name: 'member-emilija', // changed
+              },
+              {
+                kind: 'tm',
+                name: 'member-filip', // changed
+              },
+            ],
+          },
+          {
+            kind: 'tc',
+            name: 'sikavica', // changed
+            children: [
+              {
+                kind: 'tm',
+                name: 'member-blagoja', // changed
+              },
+              {
+                kind: 'tm',
+                name: 'member-goran', // changed
+              },
+            ],
+          },
+          {
+            kind: 'tc',
+            name: 'ognen',
+          },
+        ],
+      })
+    )
+  })
+})

--- a/packages/core/src/zip/edit.js
+++ b/packages/core/src/zip/edit.js
@@ -1,0 +1,21 @@
+'use strict'
+
+import { curry } from 'ramda'
+import { isOfKind } from '../data'
+import { postWalk } from '../zip'
+
+export const editCond = curry((patterns, zipper) =>
+  postWalk(el => {
+    patterns.forEach(pattern => {
+      const pred = pattern[0]
+      const updateFn = pattern[1]
+      if (
+        (typeof pred === 'function' && pred(el)) ||
+        (typeof pred !== 'function' && isOfKind(pred, el))
+      ) {
+        el = updateFn(el)
+      }
+    })
+    return el
+  }, zipper)
+)

--- a/packages/core/src/zip/index.js
+++ b/packages/core/src/zip/index.js
@@ -4,3 +4,4 @@ export * from '../vendor/zippa'
 
 export { default as elementZipper } from './elementZipper'
 export * from './reduce'
+export * from './edit'


### PR DESCRIPTION
Utility function that mimics the behavior of transformers: a way to walk the element tree and perform edits for given patterns.

The function has the signature:
```javascript
editCond :: patterns -> loc -> loc
```
Where patterns is an array of `[pattern, editFn]` touples.
A pattern can be either a function, in which case it is treated as a predicate; alternatively it can be an element kind expression, in which case it will match all elements of that kind.

e.g.
```javascript
zip.editCond(
  [
    [e => e.has('property'), e => e.set('updated', true),
    ['__read',  e => e.set('isRead', true),
    [['document', 'article'], e => e.set('isDocumentArticle', true)
  ],
 initialLocation
)
```

Closes #81