### PR TITLE
Enable parallelized enhancement

### DIFF
--- a/packages/core/src/enhance/impl.js
+++ b/packages/core/src/enhance/impl.js
@@ -23,11 +23,11 @@ export function extract(config) {
         R.or(R.isNil(maxNumOfArgs), R.lte(e.length, maxNumOfArgs))
       )
     )
-    if (enhancers != null && !enhancers.isEmpty()) {
+    if (!enhancers.isEmpty()) {
       const el = zip.value(loc)
       return Promise.all(
         enhancers
-          .map(e => (R.lte(e.length, 1) ? e(context) : e(el, context)))
+          .map(e => (e.length <= 1 ? e(context) : e(el, context)))
           .toArray()
       )
     }
@@ -53,8 +53,7 @@ export function execute(config) {
     return loc
   }
 
-  return async (el, ...updates) =>
-    zip.value(_execute(elementZipper(el), ...updates))
+  return (el, ...updates) => zip.value(_execute(elementZipper(el), ...updates))
 }
 
 // "compress updates"

--- a/packages/core/src/enhance/impl.js
+++ b/packages/core/src/enhance/impl.js
@@ -1,7 +1,7 @@
 'use strict'
 
 import R from 'ramda'
-import { memoize, time } from '../impl/util'
+import { memoize } from '../impl/util'
 import * as data from '../data'
 import * as zip from '../zip'
 
@@ -18,11 +18,14 @@ export function extract(config) {
       data.kindOf
     )
     const enhancers = enhancersForKind(kind).filter(e =>
-      R.and(R.gte(e.length, minNumOfArgs), R.lte(e.length, maxNumOfArgs))
+      R.and(
+        R.or(R.isNil(minNumOfArgs), R.gte(e.length, minNumOfArgs)),
+        R.or(R.isNil(maxNumOfArgs), R.lte(e.length, maxNumOfArgs))
+      )
     )
     if (enhancers != null && !enhancers.isEmpty()) {
       const el = zip.value(loc)
-      return time(`TIME-enhance-(${kind})`, Promise.all)(
+      return Promise.all(
         enhancers
           .map(e => (R.lte(e.length, 1) ? e(context) : e(el, context)))
           .toArray()

--- a/packages/core/src/enhance/impl.js
+++ b/packages/core/src/enhance/impl.js
@@ -68,7 +68,13 @@ export function extractUpdates(config) {
   async function _extractUpdates(loc, context) {
     const { elementZipper } = context
 
-    const kind = data.flow(loc, zip.value, data.kindOf)
+    const kind = data.flow(
+      loc,
+      zip.value,
+      el =>
+        el.update('kind', kind => kind.filterNot(term => term === '__loading')),
+      data.kindOf
+    )
     const enhancers = enhancersForKind(kind)
     if (enhancers != null) {
       let updates = await time(`TIME-ehnace-(${kind})`, Promise.all)(
@@ -99,7 +105,6 @@ export function executeUpdates(config) {
   return async (el, updates) =>
     zip.value(_executeUpdates(elementZipper(el), updates))
 }
-
 
 // "compress updates"
 // partition the updates into runs of consequtive arrays / funtons

--- a/packages/core/src/enhance/impl.js
+++ b/packages/core/src/enhance/impl.js
@@ -35,7 +35,7 @@ export function extract(config) {
     return []
   }
 
-  return async (el, context = {}) => await _extract(elementZipper(el), context)
+  return async (el, context = {}) => _extract(elementZipper(el), context)
 }
 
 export function execute(config) {

--- a/packages/core/src/enhance/index.js
+++ b/packages/core/src/enhance/index.js
@@ -51,10 +51,19 @@ export default SubSystem.create(system => ({
     if (combinedRegistry == null) {
       return x => Promise.resolve(x)
     }
-    return impl.enhancer({
-      registry: combinedRegistry,
-      elementZipper: system.elementZipper,
-    })
+    return {
+      enhancer: impl.enhancer({
+        registry: combinedRegistry,
+        elementZipper: system.elementZipper,
+      }),
+      extractUpdates: impl.extractUpdates({
+        registry: combinedRegistry,
+        elementZipper: system.elementZipper,
+      }),
+      executeUpdates: impl.executeUpdates({
+        elementZipper: system.elementZipper,
+      }),
+    }
   },
 }))
 

--- a/packages/core/src/enhance/index.js
+++ b/packages/core/src/enhance/index.js
@@ -55,14 +55,12 @@ export default SubSystem.create(system => ({
       extractContextBased: impl.extract({
         registry: combinedRegistry,
         elementZipper: system.elementZipper,
-        minNumOfArgs: 0,
         maxNumOfArgs: 1,
       }),
       extractElementBased: impl.extract({
         registry: combinedRegistry,
         elementZipper: system.elementZipper,
         minNumOfArgs: 2,
-        maxNumOfArgs: 2,
       }),
       execute: impl.execute({
         elementZipper: system.elementZipper,

--- a/packages/core/src/enhance/index.js
+++ b/packages/core/src/enhance/index.js
@@ -52,10 +52,10 @@ export default SubSystem.create(system => ({
       return x => Promise.resolve(x)
     }
     return {
-      enhancer: impl.enhancer({
-        registry: combinedRegistry,
-        elementZipper: system.elementZipper,
-      }),
+      // enhancer: impl.enhancer({
+      //   registry: combinedRegistry,
+      //   elementZipper: system.elementZipper,
+      // }),
       extractUpdates: impl.extractUpdates({
         registry: combinedRegistry,
         elementZipper: system.elementZipper,

--- a/packages/core/src/enhance/index.js
+++ b/packages/core/src/enhance/index.js
@@ -52,15 +52,19 @@ export default SubSystem.create(system => ({
       return x => Promise.resolve(x)
     }
     return {
-      // enhancer: impl.enhancer({
-      //   registry: combinedRegistry,
-      //   elementZipper: system.elementZipper,
-      // }),
-      extractUpdates: impl.extractUpdates({
+      extractContextBased: impl.extract({
         registry: combinedRegistry,
         elementZipper: system.elementZipper,
+        minNumOfArgs: 0,
+        maxNumOfArgs: 1,
       }),
-      executeUpdates: impl.executeUpdates({
+      extractElementBased: impl.extract({
+        registry: combinedRegistry,
+        elementZipper: system.elementZipper,
+        minNumOfArgs: 2,
+        maxNumOfArgs: 2,
+      }),
+      execute: impl.execute({
         elementZipper: system.elementZipper,
       }),
     }

--- a/packages/core/src/read/impl.js
+++ b/packages/core/src/read/impl.js
@@ -129,7 +129,13 @@ export async function performRead(context, readParams) {
         opts,
         R.pick(['config', 'subsystems', 'subsystemSequence'], context)
       ),
-      enhancement.extractUpdates(initialValue, enhanceContext, 1),
+      time(
+        `TIME-enhancement-context-based-(${uri})`,
+        enhancement.extractUpdates
+      )(initialValue, enhanceContext, {
+        minNumberOfArgs: 0,
+        maxNumberOfArgs: 1,
+      }),
     ])
 
     if (!isResponse(readResponse)) {
@@ -147,10 +153,18 @@ export async function performRead(context, readParams) {
         readValue,
       }
 
+      const elementBasedEnhancements = await time(
+        `TIME-enhancement-element-based-(${uri})`,
+        enhancement.extractUpdates
+      )(readValue, enhanceContext, {
+        minNumberOfArgs: 2,
+        maxNumberOfArgs: 2,
+      })
+
       const enhancedResponse = await time(
         `TIME-enhancement-(${uri})`,
         enhancement.executeUpdates
-      )(readValue, contextBasedEnhancements)
+      )(readValue, contextBasedEnhancements, elementBasedEnhancements)
 
       const enrichContext = {
         ...enhanceContext,

--- a/packages/core/src/read/impl.js
+++ b/packages/core/src/read/impl.js
@@ -104,7 +104,7 @@ export async function performRead(context, readParams) {
     }
 
     const [readResponse, contextBasedEnhancements] = await time(
-      `TIME-reader-enhancement-parallel-(${uri})`,
+      `TIME-reader-plus-enhancement-(${uri})`,
       Promise.all
     )([
       time(`TIME-reader-(${uri})`, reader)(
@@ -113,7 +113,7 @@ export async function performRead(context, readParams) {
         R.pick(['config', 'subsystems', 'subsystemSequence'], context)
       ),
       time(
-        `TIME-enhancement-context-based-(${uri})`,
+        `TIME-enhancement-extract-context-based-(${uri})`,
         enhancement.extractContextBased
       )(initialValue, enhanceContext),
     ])
@@ -134,12 +134,12 @@ export async function performRead(context, readParams) {
       }
 
       const elementBasedEnhancements = await time(
-        `TIME-enhancement-element-based-(${uri})`,
+        `TIME-enhancement-extract-element-based-(${uri})`,
         enhancement.extractElementBased
       )(readValue, enhanceContext)
 
-      const enhancedResponse = await time(
-        `TIME-enhancement-(${uri})`,
+      const enhancedResponse = timeSync(
+        `TIME-enhancement-execute-(${uri})`,
         enhancement.execute
       )(readValue, contextBasedEnhancements, elementBasedEnhancements)
 

--- a/packages/core/src/read/impl.js
+++ b/packages/core/src/read/impl.js
@@ -129,10 +129,7 @@ export async function performRead(context, readParams) {
         opts,
         R.pick(['config', 'subsystems', 'subsystemSequence'], context)
       ),
-      time(`TIME-enhancement-updates-(${uri})`, enhancement.extractUpdates)(
-        initialValue,
-        enhanceContext
-      ),
+      enhancement.extractUpdates(initialValue, enhanceContext, 1),
     ])
 
     if (!isResponse(readResponse)) {


### PR DESCRIPTION
**NOTE**: This is not a pull request towards master, only towards `optimize-enhancers`

This PR will:
- Split the enhancement process into two parts: `extract` and `execute`
  - `extract` results with updates
  - `execute` applies those updates
- Expose two types of extractions: context-based and element-based
- Parallelize context-based extraction with the read
- Do element-based extraction after the read
- Execute all extracted updates together and pass on the enhanced response