### PR TITLE
Enhance Improvements: pattern-based results as options and read-independent enhancers support

### DIFF
--- a/packages/core/src/enhance/__tests__/enhance.js
+++ b/packages/core/src/enhance/__tests__/enhance.js
@@ -24,32 +24,46 @@ describe('Enhancers', () => {
       {
         kind: 'teaser',
         data: 10,
+        value: 1,
       },
       {
         kind: 'teaser',
         data: 20,
+        value: 2,
       },
     ],
   }
 
-  const incrementData = async el => {
+  const increment = prop => async (el, context) => {
     await sleep(randomMs(100))
 
-    return el => el.update('data', d => d + 1)
+    return el => el.update(prop, d => d + 1)
   }
+  const incrementData = increment('data')
 
+  // deprecated enhancers: enhance.register :: async (el, context) => el => el
   enhance.register('document', incrementData)
   enhance.register('teaser', incrementData)
 
+  // preferred enhancers: enhance.register :: async (context) => [[pattern, el => el], ...]
+  enhance.register('document', async context => {
+    await sleep(randomMs(100))
+    return [[['teaser'], el => el.update('value', v => v + 1)]]
+  })
+
   test('enhancers should run only for root element', async () => {
     const kernel = Kernel.create([enhanceSubsystem, app], appState, {})
-    const enhancer = kernel.subsystems.enhance.buildEnhancer()
+    const enhancement = kernel.subsystems.enhance.buildEnhancer()
 
-    const result = await enhancer(fromJS(appState))
+    const result = await enhancement(fromJS(appState), {
+      elementZipper: kernel.elementZipper,
+    })
 
     expect(result.get('data')).toEqualI(2)
     expect(result.getIn(['children', 0, 'data'])).toEqualI(10)
     expect(result.getIn(['children', 1, 'data'])).toEqualI(20)
+    expect(result.getIn(['children', 0, 'value'])).toEqualI(2)
+    expect(result.getIn(['children', 1, 'value'])).toEqualI(3)
   })
 
   const appendItem = item => async el => {
@@ -61,11 +75,13 @@ describe('Enhancers', () => {
   enhance.register(['document'], appendItem(10))
   enhance.register(['document'], appendItem(100))
 
-  test('enhancers should apply all registered enhancments', async () => {
+  test('enhancers should apply all registered enhancements', async () => {
     const kernel = Kernel.create([enhanceSubsystem, app], appState, {})
-    const enhancer = kernel.subsystems.enhance.buildEnhancer()
+    const enhancement = kernel.subsystems.enhance.buildEnhancer()
 
-    const result = await enhancer(fromJS(appState))
+    const result = await enhancement(fromJS(appState), {
+      elementZipper: kernel.elementZipper,
+    })
 
     expect(result.get('items')).toEqualI(List.of(1, 2, 3, 10, 100))
   })

--- a/packages/core/src/enhance/__tests__/enhance.js
+++ b/packages/core/src/enhance/__tests__/enhance.js
@@ -35,13 +35,6 @@ describe('Enhancers', () => {
     ],
   }
 
-  const increment = prop => async (el, context) => {
-    await sleep(randomMs(100))
-
-    return el => el.update(prop, d => d + 1)
-  }
-  const incrementData = increment('data')
-
   // deprecated enhancers: enhance.register :: async (el, context) => el => el
   // read dependent enhancers
   enhance.register('document', async (el, context) => {

--- a/packages/core/src/enhance/impl.js
+++ b/packages/core/src/enhance/impl.js
@@ -5,6 +5,28 @@ import { memoize } from '../impl/util'
 import * as data from '../data'
 import * as zip from '../zip'
 
+
+// use this one to decorate  async functions with timing
+export function time(note, fn) {
+  return async (...args) => {
+    const start = Date.now()
+    const result = await fn(...args)
+    const end = Date.now()
+    console.log(`${note} took ${end - start} ms`)
+    return result
+  }
+}
+
+export function time2(note, fn) {
+  return (...args) => {
+    const start = Date.now()
+    const result = fn(...args)
+    const end = Date.now()
+    console.log(`${note} took ${end - start} ms`)
+    return result
+  }
+}
+
 export function enhancer(config) {
   const { registry, elementZipper } = config
 
@@ -14,12 +36,17 @@ export function enhancer(config) {
   })
 
   async function enhance(loc, context) {
-    const enhancers = data.flow(loc, zip.value, data.kindOf, enhancersForKind)
+    const { elementZipper } = context
+
+    const kind = data.flow(loc, zip.value, data.kindOf)
+    const enhancers = enhancersForKind(kind)
     if (enhancers != null) {
       const el = zip.value(loc)
-      const updates = await Promise.all(
+      let updates = await time(`TIME-ehnace-(${kind})`, Promise.all)(
         enhancers.map(e => e(el, context)).toArray()
       )
+      // debugger
+      updates = compressUpdates(updates, elementZipper)
       const enhancedValue = R.reduce((v, u) => u(v), el, updates)
       loc = zip.replace(enhancedValue, loc)
     }
@@ -30,3 +57,30 @@ export function enhancer(config) {
   return async (el, context = {}) =>
     zip.value(await enhance(elementZipper(el), context))
 }
+
+// "compress updates"
+// partition the updates into runs of consequtive arrays / funtons
+// convert consequtive arrays into a single editCond call
+
+function compressUpdates(updates, elementZipper) {
+  const slices = partitionBy(Array.isArray, updates)
+
+  return R.chain(
+    R.when(R.pipe(R.head, Array.isArray),
+      slice => [R.pipe(elementZipper, zip.editCond(concatAll(slice)), zip.value)]),
+    slices)
+}
+
+function partitionBy(fn, list) {
+  if (!R.isEmpty(list)) {
+    const v = R.head(list)
+    const fv = fn(v)
+    const run = [v, ...R.takeWhile(x => R.equals(fv, fn(x)), R.tail(list))]
+
+    return [run, ...partitionBy(fn, R.drop(R.length(run), list))]
+  }
+
+  return []
+}
+
+const concatAll = lists => R.reduce(R.concat, [], lists)

--- a/packages/core/src/enhance/impl.js
+++ b/packages/core/src/enhance/impl.js
@@ -23,11 +23,11 @@ export function extract(config) {
         R.or(R.isNil(maxNumOfArgs), R.lte(e.length, maxNumOfArgs))
       )
     )
-    if (enhancers != null && !enhancers.isEmpty()) {
+    if (!enhancers.isEmpty()) {
       const el = zip.value(loc)
       return Promise.all(
         enhancers
-          .map(e => (R.lte(e.length, 1) ? e(context) : e(el, context)))
+          .map(e => (e.length <= 1 ? e(context) : e(el, context)))
           .toArray()
       )
     }
@@ -53,8 +53,7 @@ export function execute(config) {
     return loc
   }
 
-  return async (el, ...updates) =>
-    zip.value(_execute(elementZipper(el), ...updates))
+  return (el, ...updates) => zip.value(_execute(elementZipper(el), ...updates))
 }
 
 // "compress updates"

--- a/packages/core/src/enhance/impl.js
+++ b/packages/core/src/enhance/impl.js
@@ -1,7 +1,7 @@
 'use strict'
 
 import R from 'ramda'
-import { memoize, time } from '../impl/util'
+import { memoize } from '../impl/util'
 import * as data from '../data'
 import * as zip from '../zip'
 
@@ -18,11 +18,14 @@ export function extract(config) {
       data.kindOf
     )
     const enhancers = enhancersForKind(kind).filter(e =>
-      R.and(R.gte(e.length, minNumOfArgs), R.lte(e.length, maxNumOfArgs))
+      R.and(
+        R.or(R.isNil(minNumOfArgs), R.gte(e.length, minNumOfArgs)),
+        R.or(R.isNil(maxNumOfArgs), R.lte(e.length, maxNumOfArgs))
+      )
     )
     if (enhancers != null && !enhancers.isEmpty()) {
       const el = zip.value(loc)
-      return time(`TIME-enhance-(${kind})`, Promise.all)(
+      return Promise.all(
         enhancers
           .map(e => (R.lte(e.length, 1) ? e(context) : e(el, context)))
           .toArray()

--- a/packages/core/src/enhance/impl.js
+++ b/packages/core/src/enhance/impl.js
@@ -68,7 +68,13 @@ export function extractUpdates(config) {
   async function _extractUpdates(loc, context) {
     const { elementZipper } = context
 
-    const kind = data.flow(loc, zip.value, data.kindOf)
+    const kind = data.flow(
+      loc,
+      zip.value,
+      el =>
+        el.update('kind', kind => kind.filterNot(term => term === '__loading')),
+      data.kindOf
+    )
     const enhancers = enhancersForKind(kind)
     if (enhancers != null) {
       let updates = await time(`TIME-ehnace-(${kind})`, Promise.all)(
@@ -99,7 +105,6 @@ export function executeUpdates(config) {
   return async (el, updates) =>
     zip.value(_executeUpdates(elementZipper(el), updates))
 }
-
 
 // "compress updates"
 // partition the updates into runs of consequtive arrays / funtons

--- a/packages/core/src/enhance/impl.js
+++ b/packages/core/src/enhance/impl.js
@@ -35,7 +35,7 @@ export function extract(config) {
     return []
   }
 
-  return async (el, context = {}) => await _extract(elementZipper(el), context)
+  return async (el, context = {}) => _extract(elementZipper(el), context)
 }
 
 export function execute(config) {

--- a/packages/core/src/enhance/impl.js
+++ b/packages/core/src/enhance/impl.js
@@ -1,30 +1,9 @@
 'use strict'
 
 import R from 'ramda'
-import { memoize } from '../impl/util'
+import { memoize, time } from '../impl/util'
 import * as data from '../data'
 import * as zip from '../zip'
-
-// use this one to decorate  async functions with timing
-export function time(note, fn) {
-  return async (...args) => {
-    const start = Date.now()
-    const result = await fn(...args)
-    const end = Date.now()
-    console.log(`${note} took ${end - start} ms`)
-    return result
-  }
-}
-
-export function time2(note, fn) {
-  return (...args) => {
-    const start = Date.now()
-    const result = fn(...args)
-    const end = Date.now()
-    console.log(`${note} took ${end - start} ms`)
-    return result
-  }
-}
 
 // export function enhancer(config) {
 //   const { registry, elementZipper } = config
@@ -128,8 +107,8 @@ export function executeUpdates(config) {
 }
 
 // "compress updates"
-// partition the updates into runs of consequtive arrays / funtons
-// convert consequtive arrays into a single editCond call
+// partition the updates into runs of consecutive arrays / functions
+// convert consecutive arrays into a single editCond call
 
 function compressUpdates(updates, elementZipper) {
   const slices = partitionBy(Array.isArray, updates)

--- a/packages/core/src/enhance/index.js
+++ b/packages/core/src/enhance/index.js
@@ -51,10 +51,19 @@ export default SubSystem.create(system => ({
     if (combinedRegistry == null) {
       return x => Promise.resolve(x)
     }
-    return impl.enhancer({
-      registry: combinedRegistry,
-      elementZipper: system.elementZipper,
-    })
+    return {
+      enhancer: impl.enhancer({
+        registry: combinedRegistry,
+        elementZipper: system.elementZipper,
+      }),
+      extractUpdates: impl.extractUpdates({
+        registry: combinedRegistry,
+        elementZipper: system.elementZipper,
+      }),
+      executeUpdates: impl.executeUpdates({
+        elementZipper: system.elementZipper,
+      }),
+    }
   },
 }))
 

--- a/packages/core/src/enhance/index.js
+++ b/packages/core/src/enhance/index.js
@@ -55,14 +55,12 @@ export default SubSystem.create(system => ({
       extractContextBased: impl.extract({
         registry: combinedRegistry,
         elementZipper: system.elementZipper,
-        minNumOfArgs: 0,
         maxNumOfArgs: 1,
       }),
       extractElementBased: impl.extract({
         registry: combinedRegistry,
         elementZipper: system.elementZipper,
         minNumOfArgs: 2,
-        maxNumOfArgs: 2,
       }),
       execute: impl.execute({
         elementZipper: system.elementZipper,

--- a/packages/core/src/enhance/index.js
+++ b/packages/core/src/enhance/index.js
@@ -52,10 +52,10 @@ export default SubSystem.create(system => ({
       return x => Promise.resolve(x)
     }
     return {
-      enhancer: impl.enhancer({
-        registry: combinedRegistry,
-        elementZipper: system.elementZipper,
-      }),
+      // enhancer: impl.enhancer({
+      //   registry: combinedRegistry,
+      //   elementZipper: system.elementZipper,
+      // }),
       extractUpdates: impl.extractUpdates({
         registry: combinedRegistry,
         elementZipper: system.elementZipper,

--- a/packages/core/src/enhance/index.js
+++ b/packages/core/src/enhance/index.js
@@ -1,6 +1,7 @@
 'use strict'
 
 import R from 'ramda'
+import { List } from 'immutable'
 import invariant from 'invariant'
 
 import { isElementRef } from '../data'
@@ -10,21 +11,30 @@ import { MultivalueRegistry, chainMultivalueRegistries } from '../registry'
 
 import * as impl from './impl'
 
-const registryAttribute = '@@girders-elements/_enhanceRegistry'
+const readDependentRegistryAttribute =
+  '@@girders-elements/_readDependentEnhanceRegistry'
+const readIndependentListAttribute =
+  '@@girders-elements/_readIndependentEnhanceList'
 
 SubSystem.extend(() => {
-  const registry = new MultivalueRegistry()
+  const readDependentRegistry = new MultivalueRegistry()
+  const readIndependentList = List().asMutable()
 
   return {
     enhance: {
-      [registryAttribute]: registry,
+      [readDependentRegistryAttribute]: readDependentRegistry,
+      [readIndependentListAttribute]: readIndependentList,
 
       /**
        * Registers an enhancer for the specific kind
        */
       register(kind, enhancer) {
+        if (enhancer == null) {
+          enhancer = kind
+          kind = null
+        }
         invariant(
-          isElementRef(kind),
+          isElementRef(kind) || kind == null,
           'You must provide a valid element reference to register'
         )
         invariant(
@@ -32,11 +42,14 @@ SubSystem.extend(() => {
           'You must provide an enhancer function'
         )
 
-        registry.register(kind, enhancer)
+        kind != null
+          ? readDependentRegistry.register(kind, enhancer)
+          : readIndependentList.push(enhancer)
       },
 
       reset() {
-        registry.reset()
+        readDependentRegistry.reset()
+        readIndependentList.clear()
       },
     },
   }
@@ -45,34 +58,51 @@ SubSystem.extend(() => {
 export default SubSystem.create(system => ({
   name: 'enhance',
 
-  buildEnhancer() {
-    const combinedRegistry = getCombinedRegistry(system.subsystemSequence)
+  buildEnhanceHelper() {
+    const combinedReadDependentRegistry = getCombinedRegistry(
+      system.subsystemSequence
+    )
+    const combinedReadIndependentList = getCombinedList(
+      system.subsystemSequence
+    )
 
-    if (combinedRegistry == null) {
-      return x => Promise.resolve(x)
+    if (
+      combinedReadDependentRegistry.isEmpty() &&
+      combinedReadIndependentList.isEmpty()
+    ) {
+      return {
+        readDependentEnhancers: R.always(List()),
+        readIndependentEnhancers: R.always(List()),
+        runEnhancers: x => Promise.all([Promise.resolve(x)]),
+        // runEnhancers: x => Promise.resolve(x),
+        applyEnhancements: R.identity,
+      }
     }
+
     return {
-      extractContextBased: impl.extract({
-        registry: combinedRegistry,
-        elementZipper: system.elementZipper,
-        maxNumOfArgs: 1,
-      }),
-      extractElementBased: impl.extract({
-        registry: combinedRegistry,
-        elementZipper: system.elementZipper,
-        minNumOfArgs: 2,
-      }),
-      execute: impl.execute({
-        elementZipper: system.elementZipper,
-      }),
+      readDependentEnhancers: kind => combinedReadDependentRegistry.get(kind),
+      readIndependentEnhancers: () => combinedReadIndependentList,
+
+      runEnhancers: impl.runEnhancers,
+      applyEnhancements: impl.applyEnhancements,
     }
   },
 }))
 
-const getRegistry = R.path(['enhance', registryAttribute])
+const getRegistry = R.path(['enhance', readDependentRegistryAttribute])
 
 const getCombinedRegistry = R.pipe(
   R.map(getRegistry),
   R.reject(R.isNil),
   chainMultivalueRegistries
+)
+
+const getList = R.path(['enhance', readIndependentListAttribute])
+const iconcat = (a, b) => a.concat(b)
+
+const getCombinedList = R.pipe(
+  R.map(getList),
+  R.reject(R.isNil),
+  R.map(l => l.asImmutable()),
+  R.reduce(iconcat, List())
 )

--- a/packages/core/src/enhance/index.js
+++ b/packages/core/src/enhance/index.js
@@ -52,15 +52,19 @@ export default SubSystem.create(system => ({
       return x => Promise.resolve(x)
     }
     return {
-      // enhancer: impl.enhancer({
-      //   registry: combinedRegistry,
-      //   elementZipper: system.elementZipper,
-      // }),
-      extractUpdates: impl.extractUpdates({
+      extractContextBased: impl.extract({
         registry: combinedRegistry,
         elementZipper: system.elementZipper,
+        minNumOfArgs: 0,
+        maxNumOfArgs: 1,
       }),
-      executeUpdates: impl.executeUpdates({
+      extractElementBased: impl.extract({
+        registry: combinedRegistry,
+        elementZipper: system.elementZipper,
+        minNumOfArgs: 2,
+        maxNumOfArgs: 2,
+      }),
+      execute: impl.execute({
         elementZipper: system.elementZipper,
       }),
     }

--- a/packages/core/src/enrich/impl.js
+++ b/packages/core/src/enrich/impl.js
@@ -8,6 +8,8 @@ import * as zip from '../zip'
 export function enricher(config) {
   const { registry, elementZipper } = config
 
+  if (registry.isEmpty()) return async (el, context = {}) => el // identity
+
   const elementEnricher = memoize(kind => {
     const enrichers = registry.get(kind)
     return enrichers.isEmpty()

--- a/packages/core/src/impl/util.js
+++ b/packages/core/src/impl/util.js
@@ -21,3 +21,31 @@ export function memoize(fn) {
     return res === notPresent ? undefined : res
   }
 }
+
+// Use to time an async function
+export function time(note, fn) {
+  if (process.env.GIRDERS_PROFILING !== 'enable') {
+    return fn
+  }
+  return async (...args) => {
+    const start = Date.now()
+    const result = await fn(...args)
+    const end = Date.now()
+    console.log(`${note} took ${end - start} ms`)
+    return result
+  }
+}
+
+// Use to time a sync function
+export function timeSync(note, fn) {
+  if (process.env.GIRDERS_PROFILING !== 'enable') {
+    return fn
+  }
+  return (...args) => {
+    const start = Date.now()
+    const result = fn(...args)
+    const end = Date.now()
+    console.log(`${note} took ${end - start} ms`)
+    return result
+  }
+}

--- a/packages/core/src/read/impl.js
+++ b/packages/core/src/read/impl.js
@@ -129,7 +129,13 @@ export async function performRead(context, readParams) {
         opts,
         R.pick(['config', 'subsystems', 'subsystemSequence'], context)
       ),
-      enhancement.extractUpdates(initialValue, enhanceContext, 1),
+      time(
+        `TIME-enhancement-context-based-(${uri})`,
+        enhancement.extractUpdates
+      )(initialValue, enhanceContext, {
+        minNumberOfArgs: 0,
+        maxNumberOfArgs: 1,
+      }),
     ])
 
     if (!isResponse(readResponse)) {
@@ -147,10 +153,18 @@ export async function performRead(context, readParams) {
         readValue,
       }
 
+      const elementBasedEnhancements = await time(
+        `TIME-enhancement-element-based-(${uri})`,
+        enhancement.extractUpdates
+      )(readValue, enhanceContext, {
+        minNumberOfArgs: 2,
+        maxNumberOfArgs: 2,
+      })
+
       const enhancedResponse = await time(
         `TIME-enhancement-(${uri})`,
         enhancement.executeUpdates
-      )(readValue, contextBasedEnhancements)
+      )(readValue, contextBasedEnhancements, elementBasedEnhancements)
 
       const enrichContext = {
         ...enhanceContext,

--- a/packages/core/src/read/impl.js
+++ b/packages/core/src/read/impl.js
@@ -90,7 +90,6 @@ export async function performRead(context, readParams) {
   } = context.subsystems.read.context
 
   const kernel = context
-  const initialValue = kernel.query()
 
   const { uri, opts } = readParams
   const reader = registry.get(uri) || registry.get(fallback)

--- a/packages/core/src/read/impl.js
+++ b/packages/core/src/read/impl.js
@@ -104,7 +104,7 @@ export async function performRead(context, readParams) {
     }
 
     const [readResponse, contextBasedEnhancements] = await time(
-      `TIME-reader-enhancement-parallel-(${uri})`,
+      `TIME-reader-plus-enhancement-(${uri})`,
       Promise.all
     )([
       time(`TIME-reader-(${uri})`, reader)(
@@ -113,7 +113,7 @@ export async function performRead(context, readParams) {
         R.pick(['config', 'subsystems', 'subsystemSequence'], context)
       ),
       time(
-        `TIME-enhancement-context-based-(${uri})`,
+        `TIME-enhancement-extract-context-based-(${uri})`,
         enhancement.extractContextBased
       )(initialValue, enhanceContext),
     ])
@@ -134,12 +134,12 @@ export async function performRead(context, readParams) {
       }
 
       const elementBasedEnhancements = await time(
-        `TIME-enhancement-element-based-(${uri})`,
+        `TIME-enhancement-extract-element-based-(${uri})`,
         enhancement.extractElementBased
       )(readValue, enhanceContext)
 
-      const enhancedResponse = await time(
-        `TIME-enhancement-(${uri})`,
+      const enhancedResponse = timeSync(
+        `TIME-enhancement-execute-(${uri})`,
         enhancement.execute
       )(readValue, contextBasedEnhancements, elementBasedEnhancements)
 

--- a/packages/core/src/read/impl.js
+++ b/packages/core/src/read/impl.js
@@ -129,10 +129,7 @@ export async function performRead(context, readParams) {
         opts,
         R.pick(['config', 'subsystems', 'subsystemSequence'], context)
       ),
-      time(`TIME-enhancement-updates-(${uri})`, enhancement.extractUpdates)(
-        initialValue,
-        enhanceContext
-      ),
+      enhancement.extractUpdates(initialValue, enhanceContext, 1),
     ])
 
     if (!isResponse(readResponse)) {

--- a/packages/core/src/read/impl.js
+++ b/packages/core/src/read/impl.js
@@ -7,6 +7,7 @@ import { fromJS } from 'immutable'
 import uuid from 'uuid'
 
 import { info, error } from '../impl/log'
+import { time, timeSync } from '../impl/util'
 
 import { canonical, flow } from '../data'
 import * as readActions from './actions'
@@ -80,27 +81,6 @@ export function fail(element, action) {
   )
 }
 
-// use this one to decorate  async functions with timing
-export function time(note, fn) {
-  return async (...args) => {
-    const start = Date.now()
-    const result = await fn(...args)
-    const end = Date.now()
-    console.log(`${note} took ${end - start} ms`)
-    return result
-  }
-}
-
-export function time2(note, fn) {
-  return (...args) => {
-    const start = Date.now()
-    const result = fn(...args)
-    const end = Date.now()
-    console.log(`${note} took ${end - start} ms`)
-    return result
-  }
-}
-
 export async function performRead(context, readParams) {
   const {
     registry,
@@ -153,10 +133,7 @@ export async function performRead(context, readParams) {
         readValue,
       }
 
-      const elementBasedEnhancements = await time(
-        `TIME-enhancement-element-based-(${uri})`,
-        enhancement.extractUpdates
-      )(readValue, enhanceContext, {
+      const elementBasedEnhancements = await time(`TIME-enhancement-element-based-(${uri})`, enhancement.extractUpdates)(readValue, enhanceContext, {
         minNumberOfArgs: 2,
         maxNumberOfArgs: 2,
       })
@@ -181,10 +158,10 @@ export async function performRead(context, readParams) {
         readValue: enrichedResponse,
       }
 
-      const transformedResponse = time2(
-        `TIME-transformation-(${uri})`,
-        transformation
-      )(enrichedResponse, transformContext)
+      const transformedResponse = timeSync(`TIME-transformation-(${uri})`, transformation
+        )(enrichedResponse,
+        transformContext
+      )
 
       return { ...readResponse, value: transformedResponse }
     } else {

--- a/packages/core/src/read/index.js
+++ b/packages/core/src/read/index.js
@@ -63,7 +63,7 @@ const read = SubSystem.create((system, instantiatedSubsystems) => {
 
   const registry = getCombinedRegistry(system.subsystemSequence)
   const enrichment = instantiatedSubsystems.enrich.buildEnricher()
-  const enhancement = instantiatedSubsystems.enhance.buildEnhancer()
+  const enhancement = instantiatedSubsystems.enhance.buildEnhanceHelper()
   const transformation = instantiatedSubsystems.transform.buildTransformer()
 
   const config = {

--- a/packages/core/src/registry/AbstractRegistry.js
+++ b/packages/core/src/registry/AbstractRegistry.js
@@ -12,6 +12,10 @@ export default class AbstractRegistry {
     return this._getBySpecificity(resolvedKey, true)
   }
 
+  isEmpty() {
+    return true
+  }
+
   reset() {
     throw new Error('Must be implemented')
   }

--- a/packages/core/src/registry/PatternRegistry.js
+++ b/packages/core/src/registry/PatternRegistry.js
@@ -23,6 +23,9 @@ export default class PatternRegistry extends AbstractRegistry {
     this._registry = this._registry.push(pattern)
   }
 
+  isEmpty() {
+    return this._registry.count() === 0
+  }
   reset() {
     this._registry = new List()
   }

--- a/packages/core/src/registry/Registry.js
+++ b/packages/core/src/registry/Registry.js
@@ -15,6 +15,10 @@ export default class Registry extends AbstractRegistry {
     this._registry = this._registry.set(adaptedKey, element)
   }
 
+  isEmpty() {
+    return this._registry.count() === 0
+  }
+
   reset() {
     this._registry = new Map()
   }

--- a/packages/core/src/registry/RegistryChain.js
+++ b/packages/core/src/registry/RegistryChain.js
@@ -27,6 +27,10 @@ export class RegistryChain extends AbstractRegistry {
     return this._getBySpecificity(key, true)
   }
 
+  isEmpty() {
+    return this._primaryRegistry.isEmpty() && this._fallbackRegistry.isEmpty()
+  }
+
   _getInternal(key) {
     let val = this._primaryRegistry._getInternal(
       this._primaryRegistry._adaptKey(key)
@@ -90,6 +94,8 @@ export class MultivalueRegistryChain extends AbstractRegistry {
 
 MultivalueRegistryChain.prototype._getBySpecificity =
   MultivalueRegistry.prototype._getBySpecificity
+
+MultivalueRegistryChain.prototype.isEmpty = RegistryChain.prototype.isEmpty
 
 const chain = (Chain, Zero) =>
   R.cond([


### PR DESCRIPTION
Add support for allowing **_editCond-style_ patterns** as a return value for enhancers. With this, we will run those updates in an optimized way.

Add support for **read-independent enhancers**. These enhancers are not connected with a certain kind, but are executed in parallel with the read.

With the above changes, the enhance API now is the following:
```javascript
// registration (read-dependent)
enhance.register(kind, enhancer)

// enhancer signature (read-dependent)
enhancer :: async (el, context) => (el => el) || [[pattern, el => el], ...]

// registration (read-independent)
enhance.register(enhancer)

// enhancer signature (read-independent)
enhancer :: async context => (el => el) || [[pattern, el => el], ...]
```

Bonus: enrichers tree-walk is not done when there are no registered enrichers.
