### PR TITLE
Fix sync effect

### DIFF
--- a/packages/core/src/effect/__tests__/effects.js
+++ b/packages/core/src/effect/__tests__/effects.js
@@ -46,7 +46,11 @@ describe('effects API', function() {
 
     // a typical effect that updates the element state when finishing
 
-    effect.register(['article'], 'mark', async (context, action) => {
+    effect.register(['article'], 'mark', (context, action) => {
+      return el => el.set('marked', action.type)
+    })
+
+    effect.register(['article'], 'mark-async', async (context, action) => {
       await sleep(50)
       return el => el.set('marked', action.type)
     })
@@ -142,15 +146,25 @@ describe('effects API', function() {
       test('Effect can return an updating fn state => newState', async () => {
         const focus = kernel.focusOn(['element1', 'element2', 'element3'])
 
+        expect(focus.query().get('marked')).not.toEqual('mark')
+
         focus.dispatch({ type: 'mark' })
+
+        expect(focus.query().get('marked')).toEqual('mark')
+      })
+
+      test('An async effect can return an updating fn state => newState', async () => {
+        const focus = kernel.focusOn(['element1', 'element2', 'element3'])
+
+        focus.dispatch({ type: 'mark-async' })
 
         await sleep(25)
 
-        expect(focus.query().get('marked')).not.toEqual('mark')
+        expect(focus.query().get('marked')).not.toEqual('mark-async')
 
         await sleep(50)
 
-        expect(focus.query().get('marked')).toEqual('mark')
+        expect(focus.query().get('marked')).toEqual('mark-async')
       })
 
       test('An async effect can return undefined', () => {

--- a/packages/core/src/effect/impl.js
+++ b/packages/core/src/effect/impl.js
@@ -49,7 +49,7 @@ export const middleware = R.curry((config, store, next, action) => {
           error('Exception while executing an effect: ', e)
         })
     } else if (typeof result === 'function') {
-      context.dispatch({ type: updateStateAction, result })
+      context.dispatch({ type: updateStateAction, updateFn: result })
     }
   } else {
     // the effect consumes the action


### PR DESCRIPTION
The update function was not passed properly when dispatching an internal action for updating the state, in case of a sync effect.