### PR TITLE
Fix ramda imports (v0.25 does not support default imports)

### DIFF
--- a/packages/config/src/layer.js
+++ b/packages/config/src/layer.js
@@ -1,4 +1,4 @@
-import { pickBy, reverse } from 'ramda'
+import * as R from 'ramda'
 import deepMerge from './utils/merge'
 import deepFreeze from './utils/freeze'
 
@@ -22,7 +22,7 @@ export default class Layer {
     // and overridden with values from the more important profiles
     let activeProfiles = profiles
     if (profiles) {
-      activeProfiles = reverse(profiles)
+      activeProfiles = R.reverse(profiles)
     }
 
     // create a sequence of layers, starting from the current one, up to the root, in reverse order (root comes first)
@@ -43,7 +43,7 @@ export default class Layer {
       Object.entries(layer.configuration).forEach(
         ([feature, configOfLayer]) => {
           // values from (default) profile
-          const defaultProfileForLayer = pickBy(
+          const defaultProfileForLayer = R.pickBy(
             (val, key) => key !== 'profiles',
             configOfLayer
           )

--- a/packages/config/src/utils/merge.js
+++ b/packages/config/src/utils/merge.js
@@ -1,7 +1,7 @@
-import { is, mergeWith } from 'ramda'
+import * as R from 'ramda'
 
 export default function deepMerge(a = {}, b = {}) {
-  return is(Array, b) && !is(Object, b[0])
+  return R.is(Array, b) && !R.is(Object, b[0])
     ? b
-    : is(Object, a) && is(Object, b) ? mergeWith(deepMerge, a, b) : b
+    : R.is(Object, a) && R.is(Object, b) ? R.mergeWith(deepMerge, a, b) : b
 }

--- a/packages/core/src/action.js
+++ b/packages/core/src/action.js
@@ -1,6 +1,6 @@
 'use strict'
 
-import R from 'ramda'
+import { curry, prop } from 'ramda'
 import { kindOf } from './data'
 
 export const actionMetaProperty = '@@girders-elements/_actionMeta'
@@ -8,13 +8,13 @@ export const actionMetaProperty = '@@girders-elements/_actionMeta'
 /**
  * gets the action meadata from the action
  */
-export const actionMeta = R.prop(actionMetaProperty)
+export const actionMeta = prop(actionMetaProperty)
 
 /**
  * Sets the action's metadata to reflect the element (cursor) at which the
  * the action was fired.
  */
-export const atCursor = R.curry((cursor, action) => {
+export const atCursor = curry((cursor, action) => {
   const keyPath = cursor._keyPath
   const kind = kindOf(cursor)
 

--- a/packages/core/src/action.js
+++ b/packages/core/src/action.js
@@ -1,6 +1,6 @@
 'use strict'
 
-import { curry, prop } from 'ramda'
+import * as R from 'ramda'
 import { kindOf } from './data'
 
 export const actionMetaProperty = '@@girders-elements/_actionMeta'
@@ -8,13 +8,13 @@ export const actionMetaProperty = '@@girders-elements/_actionMeta'
 /**
  * gets the action meadata from the action
  */
-export const actionMeta = prop(actionMetaProperty)
+export const actionMeta = R.prop(actionMetaProperty)
 
 /**
  * Sets the action's metadata to reflect the element (cursor) at which the
  * the action was fired.
  */
-export const atCursor = curry((cursor, action) => {
+export const atCursor = R.curry((cursor, action) => {
   const keyPath = cursor._keyPath
   const kind = kindOf(cursor)
 

--- a/packages/core/src/data/element.js
+++ b/packages/core/src/data/element.js
@@ -1,7 +1,7 @@
 /* @flow */
 'use strict'
 
-import { all, curry } from 'ramda'
+import * as R from 'ramda'
 import invariant from 'invariant'
 import {
   List,
@@ -21,7 +21,7 @@ import type { ElementRef, ElementRefCanonical } from './types'
  * @param element the element
  * @returns {*}
  */
-export const isOfKind = curry(function isOfKind(
+export const isOfKind = R.curry(function isOfKind(
   kind: ElementRef,
   element: ?KeyedIterable
 ): boolean {
@@ -45,7 +45,7 @@ export function isElementRef(obj: any): boolean {
   const isString = o => typeof o === 'string'
 
   if (isString(obj)) return true
-  if (Array.isArray(obj) && (all(isString)(obj) || obj.length === 0))
+  if (Array.isArray(obj) && (R.all(isString)(obj) || obj.length === 0))
     return true
   if (obj instanceof List && (obj.every(isString) || obj.isEmpty())) return true
 
@@ -59,7 +59,7 @@ export function isElementRef(obj: any): boolean {
  * @param element tne element
  * @returns {*}
  */
-export const isExactlyOfKind = curry(function isExactlyOfKind(
+export const isExactlyOfKind = R.curry(function isExactlyOfKind(
   kind: ElementRef,
   element: ?KeyedIterable
 ): boolean {

--- a/packages/core/src/data/index.js
+++ b/packages/core/src/data/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-import { reduce } from 'ramda'
+import * as R from 'ramda'
 import * as element from './element'
 export * from './element'
 
@@ -9,7 +9,7 @@ export { element } // deprecated use
 /**
  * Like R.pipe, but the composition is immediately executed using the first arg.
  */
-export const flow = (v, ...fs) => reduce((x, f) => f(x), v, fs)
+export const flow = (v, ...fs) => R.reduce((x, f) => f(x), v, fs)
 
 /**
  * when for reduce

--- a/packages/core/src/data/index.js
+++ b/packages/core/src/data/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-import R from 'ramda'
+import { reduce } from 'ramda'
 import * as element from './element'
 export * from './element'
 
@@ -9,7 +9,7 @@ export { element } // deprecated use
 /**
  * Like R.pipe, but the composition is immediately executed using the first arg.
  */
-export const flow = (v, ...fs) => R.reduce((x, f) => f(x), v, fs)
+export const flow = (v, ...fs) => reduce((x, f) => f(x), v, fs)
 
 /**
  * when for reduce

--- a/packages/core/src/effect/impl.js
+++ b/packages/core/src/effect/impl.js
@@ -1,6 +1,6 @@
 'use strict'
 
-import R from 'ramda'
+import { curry } from 'ramda'
 
 import * as actions from '../action'
 import { types as actionTypes } from './actions'
@@ -12,7 +12,7 @@ import { error } from '../impl/log'
 
 const updateStateAction = '@@girders-elements/_effects.updateState'
 
-export const middleware = R.curry((config, store, next, action) => {
+export const middleware = curry((config, store, next, action) => {
   const { kernel, effectsRegistry } = config
   const actionMeta = actions.actionMeta(action)
 
@@ -57,7 +57,7 @@ export const middleware = R.curry((config, store, next, action) => {
   }
 })
 
-export const reducer = R.curry((config, state, action) => {
+export const reducer = curry((config, state, action) => {
   if (action.type === updateStateAction) {
     const { keyPath } = actions.actionMeta(action)
     return state.updateIn(keyPath, action.updateFn)

--- a/packages/core/src/effect/impl.js
+++ b/packages/core/src/effect/impl.js
@@ -1,6 +1,6 @@
 'use strict'
 
-import { curry } from 'ramda'
+import * as R from 'ramda'
 
 import * as actions from '../action'
 import { types as actionTypes } from './actions'
@@ -12,7 +12,7 @@ import { error } from '../impl/log'
 
 const updateStateAction = '@@girders-elements/_effects.updateState'
 
-export const middleware = curry((config, store, next, action) => {
+export const middleware = R.curry((config, store, next, action) => {
   const { kernel, effectsRegistry } = config
   const actionMeta = actions.actionMeta(action)
 
@@ -57,7 +57,7 @@ export const middleware = curry((config, store, next, action) => {
   }
 })
 
-export const reducer = curry((config, state, action) => {
+export const reducer = R.curry((config, state, action) => {
   if (action.type === updateStateAction) {
     const { keyPath } = actions.actionMeta(action)
     return state.updateIn(keyPath, action.updateFn)

--- a/packages/core/src/effect/index.js
+++ b/packages/core/src/effect/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-import R from 'ramda'
+import * as R from 'ramda'
 import invariant from 'invariant'
 
 import { chainRegistries, ActionRegistry } from '../registry'

--- a/packages/core/src/engine/__tests__/engine.js
+++ b/packages/core/src/engine/__tests__/engine.js
@@ -2,7 +2,7 @@
 
 import { mount } from 'enzyme'
 
-import R from 'ramda'
+import { curry, toUpper } from 'ramda'
 import React from 'react'
 
 import * as Subsystem from '../../subsystem'
@@ -28,7 +28,7 @@ describe('Engine: wiring everything together', () => {
     app.ui.register('c1', Foo)
     app.ui.register('c2', Foo)
 
-    const capitalize = e => e.update('text', R.toUpper)
+    const capitalize = e => e.update('text', toUpper)
     const capitalizeTitles = n => n.update('scenes', ss => ss.map(capitalize))
 
     app.update.register('nav', '.capitalize', capitalizeTitles)
@@ -119,7 +119,7 @@ describe('Engine: wiring everything together', () => {
       ui.reset()
     })
 
-    const twiddlingMiddleware = R.curry((store, next, action) => {
+    const twiddlingMiddleware = curry((store, next, action) => {
       let nextAction
       if (action.type === 'twiddle') {
         nextAction = { ...action, type: 'capitalize' }
@@ -134,7 +134,7 @@ describe('Engine: wiring everything together', () => {
       ui.register('s1', Foo)
 
       update.register('s1', updates => {
-        updates.register('capitalize', e => e.update('text', R.toUpper))
+        updates.register('capitalize', e => e.update('text', toUpper))
       })
 
       const e = mount(<Engine initState={{ kind: 's1', text: 's1' }} />)
@@ -154,7 +154,7 @@ describe('Engine: wiring everything together', () => {
       ui.register('m1', Foo)
 
       update.register('m1', updates => {
-        updates.register('capitalize', e => e.update('text', R.toUpper))
+        updates.register('capitalize', e => e.update('text', toUpper))
       })
 
       const e = mount(
@@ -179,7 +179,7 @@ describe('Engine: wiring everything together', () => {
       ui.register('ss1', Foo)
 
       update.register('ss1', updates => {
-        updates.register('capitalize', e => e.update('text', R.toUpper))
+        updates.register('capitalize', e => e.update('text', toUpper))
       })
 
       const twiddler = Subsystem.create(() => ({
@@ -210,7 +210,7 @@ describe('Engine: wiring everything together', () => {
       ui.register('ssx1', Foo)
 
       update.register('ssx1', updates => {
-        updates.register('capitalize', e => e.update('text', R.toUpper))
+        updates.register('capitalize', e => e.update('text', toUpper))
       })
 
       const twiddler = Subsystem.create(() => ({

--- a/packages/core/src/engine/__tests__/engine.js
+++ b/packages/core/src/engine/__tests__/engine.js
@@ -2,7 +2,7 @@
 
 import { mount } from 'enzyme'
 
-import { curry, toUpper } from 'ramda'
+import * as R from 'ramda'
 import React from 'react'
 
 import * as Subsystem from '../../subsystem'
@@ -28,7 +28,7 @@ describe('Engine: wiring everything together', () => {
     app.ui.register('c1', Foo)
     app.ui.register('c2', Foo)
 
-    const capitalize = e => e.update('text', toUpper)
+    const capitalize = e => e.update('text', R.toUpper)
     const capitalizeTitles = n => n.update('scenes', ss => ss.map(capitalize))
 
     app.update.register('nav', '.capitalize', capitalizeTitles)
@@ -119,7 +119,7 @@ describe('Engine: wiring everything together', () => {
       ui.reset()
     })
 
-    const twiddlingMiddleware = curry((store, next, action) => {
+    const twiddlingMiddleware = R.curry((store, next, action) => {
       let nextAction
       if (action.type === 'twiddle') {
         nextAction = { ...action, type: 'capitalize' }
@@ -134,7 +134,7 @@ describe('Engine: wiring everything together', () => {
       ui.register('s1', Foo)
 
       update.register('s1', updates => {
-        updates.register('capitalize', e => e.update('text', toUpper))
+        updates.register('capitalize', e => e.update('text', R.toUpper))
       })
 
       const e = mount(<Engine initState={{ kind: 's1', text: 's1' }} />)
@@ -154,7 +154,7 @@ describe('Engine: wiring everything together', () => {
       ui.register('m1', Foo)
 
       update.register('m1', updates => {
-        updates.register('capitalize', e => e.update('text', toUpper))
+        updates.register('capitalize', e => e.update('text', R.toUpper))
       })
 
       const e = mount(
@@ -179,7 +179,7 @@ describe('Engine: wiring everything together', () => {
       ui.register('ss1', Foo)
 
       update.register('ss1', updates => {
-        updates.register('capitalize', e => e.update('text', toUpper))
+        updates.register('capitalize', e => e.update('text', R.toUpper))
       })
 
       const twiddler = Subsystem.create(() => ({
@@ -210,7 +210,7 @@ describe('Engine: wiring everything together', () => {
       ui.register('ssx1', Foo)
 
       update.register('ssx1', updates => {
-        updates.register('capitalize', e => e.update('text', toUpper))
+        updates.register('capitalize', e => e.update('text', R.toUpper))
       })
 
       const twiddler = Subsystem.create(() => ({

--- a/packages/core/src/engine/impl.js
+++ b/packages/core/src/engine/impl.js
@@ -1,6 +1,6 @@
 'use strict'
 
-import R from 'ramda'
+import * as R from 'ramda'
 import I from 'immutable'
 import React from 'react'
 import PropTypes from 'prop-types'

--- a/packages/core/src/enhance/impl.js
+++ b/packages/core/src/enhance/impl.js
@@ -1,6 +1,6 @@
 'use strict'
 
-import R from 'ramda'
+import * as R from 'ramda'
 import I from 'immutable'
 import * as zip from '../zip'
 

--- a/packages/core/src/enhance/index.js
+++ b/packages/core/src/enhance/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-import R from 'ramda'
+import * as R from 'ramda'
 import { List } from 'immutable'
 import invariant from 'invariant'
 

--- a/packages/core/src/enrich/impl.js
+++ b/packages/core/src/enrich/impl.js
@@ -1,6 +1,6 @@
 'use strict'
 
-import { map, pipe } from 'ramda'
+import * as R from 'ramda'
 import { memoize } from '../impl/util'
 import * as data from '../data'
 import * as zip from '../zip'
@@ -28,13 +28,13 @@ export function enricher(config) {
         // prettier-ignore
         data.flow(
           zip.getChildren(loc),
-          map(pipe(elementZipper, loc => postWalk(loc, context)))
+          R.map(R.pipe(elementZipper, loc => postWalk(loc, context)))
         )
       )
       const changedValue = zip.makeItem(
         loc,
         zip.value(loc),
-        map(zip.value, changedChildren)
+        R.map(zip.value, changedChildren)
       )
 
       loc = zip.replace(changedValue, loc)

--- a/packages/core/src/enrich/impl.js
+++ b/packages/core/src/enrich/impl.js
@@ -1,6 +1,6 @@
 'use strict'
 
-import R from 'ramda'
+import { map, pipe } from 'ramda'
 import { memoize } from '../impl/util'
 import * as data from '../data'
 import * as zip from '../zip'
@@ -28,13 +28,13 @@ export function enricher(config) {
         // prettier-ignore
         data.flow(
           zip.getChildren(loc),
-          R.map(R.pipe(elementZipper, loc => postWalk(loc, context)))
+          map(pipe(elementZipper, loc => postWalk(loc, context)))
         )
       )
       const changedValue = zip.makeItem(
         loc,
         zip.value(loc),
-        R.map(zip.value, changedChildren)
+        map(zip.value, changedChildren)
       )
 
       loc = zip.replace(changedValue, loc)

--- a/packages/core/src/enrich/index.js
+++ b/packages/core/src/enrich/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-import R from 'ramda'
+import * as R from 'ramda'
 import invariant from 'invariant'
 
 import { isElementRef } from '../data'

--- a/packages/core/src/impl/cursor.js
+++ b/packages/core/src/impl/cursor.js
@@ -1,6 +1,6 @@
 'use strict'
 
-import R from 'ramda'
+import * as R from 'ramda'
 import { List, Seq } from 'immutable'
 import Cursor from 'immutable/contrib/cursor'
 

--- a/packages/core/src/kernel.js
+++ b/packages/core/src/kernel.js
@@ -2,7 +2,7 @@
 
 import I from 'immutable'
 import Cursor from 'immutable/contrib/cursor'
-import R from 'ramda'
+import * as R from 'ramda'
 
 import * as zip from './zip'
 import * as actions from './action'

--- a/packages/core/src/read/__tests__/http.js
+++ b/packages/core/src/read/__tests__/http.js
@@ -1,6 +1,6 @@
 'use strict'
 
-import R from 'ramda'
+import * as R from 'ramda'
 import * as http from '../http'
 
 describe('http', () => {

--- a/packages/core/src/read/http.js
+++ b/packages/core/src/read/http.js
@@ -1,6 +1,6 @@
 'use strict'
 
-import R from 'ramda'
+import * as R from 'ramda'
 import { fromJS } from 'immutable'
 
 export function execute(url, options) {

--- a/packages/core/src/read/impl.js
+++ b/packages/core/src/read/impl.js
@@ -1,6 +1,6 @@
 'use strict'
 
-import R from 'ramda'
+import * as R from 'ramda'
 import invariant from 'invariant'
 import { fromJS } from 'immutable'
 

--- a/packages/core/src/read/index.js
+++ b/packages/core/src/read/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-import R from 'ramda'
+import * as R from 'ramda'
 import invariant from 'invariant'
 
 // required subsystems

--- a/packages/core/src/registry/PatternRegistry.js
+++ b/packages/core/src/registry/PatternRegistry.js
@@ -2,7 +2,7 @@
 
 import AbstractRegistry from './AbstractRegistry'
 import { List, is, Iterable } from 'immutable'
-import { curryN, equals, ifElse } from 'ramda'
+import * as R from 'ramda'
 
 export default class PatternRegistry extends AbstractRegistry {
   constructor() {
@@ -18,7 +18,7 @@ export default class PatternRegistry extends AbstractRegistry {
       const regexp = key
       pattern = List.of(regexp.test.bind(regexp), value)
     } else {
-      pattern = List.of(equalsFn(key), value)
+      pattern = List.of(equals(key), value)
     }
     this._registry = this._registry.push(pattern)
   }
@@ -46,7 +46,11 @@ export default class PatternRegistry extends AbstractRegistry {
   }
 }
 
-const equalsFn = curryN(
+const equals = R.curryN(
   2,
-  ifElse((a, b) => Iterable.isIterable(a) && Iterable.isIterable(b), is, equals)
+  R.ifElse(
+    (a, b) => Iterable.isIterable(a) && Iterable.isIterable(b),
+    is,
+    R.equals
+  )
 )

--- a/packages/core/src/registry/PatternRegistry.js
+++ b/packages/core/src/registry/PatternRegistry.js
@@ -2,7 +2,7 @@
 
 import AbstractRegistry from './AbstractRegistry'
 import { List, is, Iterable } from 'immutable'
-import R from 'ramda'
+import { curryN, equals, ifElse } from 'ramda'
 
 export default class PatternRegistry extends AbstractRegistry {
   constructor() {
@@ -18,7 +18,7 @@ export default class PatternRegistry extends AbstractRegistry {
       const regexp = key
       pattern = List.of(regexp.test.bind(regexp), value)
     } else {
-      pattern = List.of(equals(key), value)
+      pattern = List.of(equalsFn(key), value)
     }
     this._registry = this._registry.push(pattern)
   }
@@ -46,11 +46,7 @@ export default class PatternRegistry extends AbstractRegistry {
   }
 }
 
-const equals = R.curryN(
+const equalsFn = curryN(
   2,
-  R.ifElse(
-    (a, b) => Iterable.isIterable(a) && Iterable.isIterable(b),
-    is,
-    R.equals
-  )
+  ifElse((a, b) => Iterable.isIterable(a) && Iterable.isIterable(b), is, equals)
 )

--- a/packages/core/src/registry/RegistryChain.js
+++ b/packages/core/src/registry/RegistryChain.js
@@ -1,6 +1,6 @@
 'use strict'
 
-import R from 'ramda'
+import * as R from 'ramda'
 
 import AbstractRegistry from './AbstractRegistry'
 import Registry from './Registry'

--- a/packages/core/src/subsystem.js
+++ b/packages/core/src/subsystem.js
@@ -1,7 +1,7 @@
 'use strict'
 
 import invariant from 'invariant'
-import R from 'ramda'
+import * as R from 'ramda'
 import uuid from 'uuid'
 
 // what is a subsystem

--- a/packages/core/src/transform/impl.js
+++ b/packages/core/src/transform/impl.js
@@ -1,6 +1,6 @@
 'use strict'
 
-import { identity } from 'ramda'
+import * as R from 'ramda'
 import { kindOf } from '../data/element'
 import { memoize } from '../impl/util'
 
@@ -11,7 +11,7 @@ export function transformer(registry, elementZipper) {
   const elementTransformer = memoize(kind =>
     registry
       .get(kind)
-      .reduce((f, g) => (x, context) => g(f(x, context), context), identity)
+      .reduce((f, g) => (x, context) => g(f(x, context), context), R.identity)
   )
 
   const transform = context => el => elementTransformer(kindOf(el))(el, context)

--- a/packages/core/src/transform/impl.js
+++ b/packages/core/src/transform/impl.js
@@ -1,6 +1,6 @@
 'use strict'
 
-import R from 'ramda'
+import { identity } from 'ramda'
 import { kindOf } from '../data/element'
 import { memoize } from '../impl/util'
 
@@ -11,7 +11,7 @@ export function transformer(registry, elementZipper) {
   const elementTransformer = memoize(kind =>
     registry
       .get(kind)
-      .reduce((f, g) => (x, context) => g(f(x, context), context), R.identity)
+      .reduce((f, g) => (x, context) => g(f(x, context), context), identity)
   )
 
   const transform = context => el => elementTransformer(kindOf(el))(el, context)

--- a/packages/core/src/transform/index.js
+++ b/packages/core/src/transform/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-import R from 'ramda'
+import * as R from 'ramda'
 import invariant from 'invariant'
 
 import { isElementRef } from '../data'

--- a/packages/core/src/ui/ElementView.js
+++ b/packages/core/src/ui/ElementView.js
@@ -1,13 +1,13 @@
 'use strict'
 
-import R from 'ramda'
+import { curry } from 'ramda'
 import I from 'immutable'
 import React from 'react'
 import PropTypes from 'prop-types'
 
 import * as data from '../data'
 
-export default R.curry((kind, Component, runtime) => {
+export default curry((kind, Component, runtime) => {
   const { uiFor: globalUIFor, system } = runtime
 
   return class extends React.Component {

--- a/packages/core/src/ui/ElementView.js
+++ b/packages/core/src/ui/ElementView.js
@@ -1,13 +1,13 @@
 'use strict'
 
-import { curry } from 'ramda'
+import * as R from 'ramda'
 import I from 'immutable'
 import React from 'react'
 import PropTypes from 'prop-types'
 
 import * as data from '../data'
 
-export default curry((kind, Component, runtime) => {
+export default R.curry((kind, Component, runtime) => {
   const { uiFor: globalUIFor, system } = runtime
 
   return class extends React.Component {

--- a/packages/core/src/ui/index.js
+++ b/packages/core/src/ui/index.js
@@ -1,8 +1,6 @@
 'use strict'
 
-'use strict'
-
-import R from 'ramda'
+import * as R from 'ramda'
 import { Iterable } from 'immutable'
 import React from 'react'
 

--- a/packages/core/src/update/impl.js
+++ b/packages/core/src/update/impl.js
@@ -1,6 +1,6 @@
 'use strict'
 
-import R from 'ramda'
+import * as R from 'ramda'
 
 import invariant from 'invariant'
 import { warning } from '../impl/log'

--- a/packages/core/src/update/index.js
+++ b/packages/core/src/update/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-import R from 'ramda'
+import * as R from 'ramda'
 import invariant from 'invariant'
 import deprecated from '../impl/deprecated'
 

--- a/packages/core/src/zip/edit.js
+++ b/packages/core/src/zip/edit.js
@@ -1,10 +1,10 @@
 'use strict'
 
-import { curry } from 'ramda'
+import * as R from 'ramda'
 import { isOfKind } from '../data'
 import { postWalk } from '../zip'
 
-export const editCond = curry((patterns, zipper) =>
+export const editCond = R.curry((patterns, zipper) =>
   postWalk(el => {
     patterns.forEach(pattern => {
       const pred = pattern[0]

--- a/packages/core/src/zip/elementZipper.js
+++ b/packages/core/src/zip/elementZipper.js
@@ -2,19 +2,19 @@
 
 import { makeZipper } from '../vendor/zippa'
 import { Iterable, List, Map } from 'immutable'
-import { curry } from 'ramda'
+import * as R from 'ramda'
 import {
   isOfKind,
   asList,
   childPositions as childPositionsFromElement,
 } from '../data'
 
-const childPositions = curry((defaultChildPositions, el) => {
+const childPositions = R.curry((defaultChildPositions, el) => {
   const fromEl = childPositionsFromElement(el)
   return !fromEl.isEmpty() ? fromEl : asList(defaultChildPositions)
 })
 
-const isBranch = curry((defaultChildPositions, element) => {
+const isBranch = R.curry((defaultChildPositions, element) => {
   if (isOfKind('@@girders-elements/child-collection', element)) {
     const children = element.get('children')
     return children && children.count() > 0
@@ -29,7 +29,7 @@ const isBranch = curry((defaultChildPositions, element) => {
   return positions.some(pos => element.get(pos))
 })
 
-const getChildren = curry((defaultChildPositions, element) => {
+const getChildren = R.curry((defaultChildPositions, element) => {
   if (isOfKind('@@girders-elements/child-collection', element)) {
     return element.get('children').toArray()
   }
@@ -55,7 +55,7 @@ const makeChildCollection = (p, children) =>
     children: asList(children),
   })
 
-const makeNode = curry((defaultChildPositions, element, children) => {
+const makeNode = R.curry((defaultChildPositions, element, children) => {
   if (isOfKind('@@girders-elements/child-collection', element)) {
     return element.set('children', List(children))
   }

--- a/packages/core/src/zip/reduce.js
+++ b/packages/core/src/zip/reduce.js
@@ -1,16 +1,16 @@
 'use strict'
 
-import { curry } from 'ramda'
+import * as R from 'ramda'
 import { onPre, onPost, visit } from '../vendor/zippa'
 
 const reduceVisitor = fn => (item, state) => ({ state: fn(state, item) })
 
-export const reduce = curry(
+export const reduce = R.curry(
   (fn, initialAcc, zipper) =>
     visit([onPost(reduceVisitor(fn))], initialAcc, zipper).state
 )
 
-export const reducePre = curry(
+export const reducePre = R.curry(
   (fn, initialAcc, zipper) =>
     visit([onPre(reduceVisitor(fn))], initialAcc, zipper).state
 )


### PR DESCRIPTION
Ramda v0.25.0 does not have a default export anymore: https://github.com/ramda/ramda/blob/master/source/index.js.
Discussion: https://github.com/ramda/ramda/issues/2322

React native apps and the tests in GE were not affected with this change (I haven't investigated this in more details, might be because of a babel plugin). However, including Girders Elements in a React app with webpack causes errors (R is undefined because there is no default export in ramda).

This PR fixes the imports.